### PR TITLE
Add Threat Detection & Highlight of Threats on Board

### DIFF
--- a/src/game-objects/board-state.js
+++ b/src/game-objects/board-state.js
@@ -1,7 +1,8 @@
-import { TILE_SIZE,X_ANCHOR,Y_ANCHOR } from './constants';
-import { PAWN,ROOK,KNIGHT,BISHOP,QUEEN,KING } from './constants';
-import { PLAYER,COMPUTER } from './constants';
+import { TILE_SIZE, X_ANCHOR, Y_ANCHOR } from './constants';
+import { PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING } from './constants';
+import { PLAYER, COMPUTER } from './constants';
 import { EN_PASSANT_TOKEN } from './constants';
+import { isSamePoint } from "./constants";
 import { ChessPiece } from './chess-piece';
 
 export class BoardState {
@@ -9,353 +10,434 @@ export class BoardState {
     #boardState;
     #enPassantCoordinate;
 
-    constructor(scene)
-    {
-        this.#scene=scene;
+    constructor(scene) {
+        this.#scene = scene;
 
-        this.#boardState=[]; // 8x8 array of chess pieces
+        this.#boardState = []; // 8x8 array of chess pieces
 
         // set up boardState & initialize player pieces (and computer pieces for testing purposes)
-        for (let i=0;i<8;i++)
-        {
+        for (let i = 0; i < 8; i++) {
             this.#boardState.push([]);
             // Initialize Player (white) pieces
-            for (let j=6;j<8;j++)
-                if (j==6)
-                    this.addPiece(i,j,PAWN,PLAYER);
+            for (let j = 6; j < 8; j++)
+                if (j == 6)
+                    this.addPiece(i, j, PAWN, PLAYER);
                 else
-                    switch (i)
-                    {
+                    switch (i) {
                         case 0:
                         case 7:
-                            this.addPiece(i,j,ROOK,PLAYER);
+                            this.addPiece(i, j, ROOK, PLAYER);
                             break;
                         case 1:
                         case 6:
-                            this.addPiece(i,j,KNIGHT,PLAYER);
+                            this.addPiece(i, j, KNIGHT, PLAYER);
                             break;
                         case 2:
                         case 5:
-                            this.addPiece(i,j,BISHOP,PLAYER);
+                            this.addPiece(i, j, BISHOP, PLAYER);
                             break;
                         case 3:
-                            this.addPiece(i,j,QUEEN,PLAYER);
+                            this.addPiece(i, j, QUEEN, PLAYER);
                             break;
                         case 4:
-                            this.addPiece(i,j,KING,PLAYER);
+                            this.addPiece(i, j, KING, PLAYER);
                             break;
                     }
             // Initialize Computer (black) pieces
-            for (let j=0;j<2;j++)
-                if (j==1)
-                    this.addPiece(i,j,PAWN,COMPUTER);
+            for (let j = 0; j < 2; j++)
+                if (j == 1)
+                    this.addPiece(i, j, PAWN, COMPUTER);
                 else
-                    switch (i)
-                    {
+                    switch (i) {
                         case 0:
                         case 7:
-                            this.addPiece(i,j,ROOK,COMPUTER);
+                            this.addPiece(i, j, ROOK, COMPUTER);
                             break;
                         case 1:
                         case 6:
-                            this.addPiece(i,j,KNIGHT,COMPUTER);
+                            this.addPiece(i, j, KNIGHT, COMPUTER);
                             break;
                         case 2:
                         case 5:
-                            this.addPiece(i,j,BISHOP,COMPUTER);
+                            this.addPiece(i, j, BISHOP, COMPUTER);
                             break;
                         case 3:
-                            this.addPiece(i,j,QUEEN,COMPUTER);
+                            this.addPiece(i, j, QUEEN, COMPUTER);
                             break;
                         case 4:
-                            this.addPiece(i,j,KING,COMPUTER);
+                            this.addPiece(i, j, KING, COMPUTER);
                             break;
                     }
         }
     }
-    
+
+    // ================================================================
+    // Check Tile Validity & Occupancy
+
     // Check whether coordinate is within bounds
-    isValid(col,row)
-    {
-        return (col>=0 && col<8 && row>=0 && row<8);
+    isValid(col, row) {
+        return (col >= 0 && col < 8 && row >= 0 && row < 8);
     }
 
     // Check whether coordinate has chess piece
-    isOccupied(col,row)
-    {
-        return this.#boardState[col][row] && this.#boardState[col][row]!=EN_PASSANT_TOKEN;
+    isOccupied(col, row, ignoreTile = null) {
+        if (ignoreTile && isSamePoint([col, row], ignoreTile))
+            return false;
+        return this.#boardState[col][row] && this.#boardState[col][row] != EN_PASSANT_TOKEN;
     }
 
     // Check whether coordinate has en passant token
-    isEnPassant(col,row)
-    {
-        return this.#boardState[col][row]==EN_PASSANT_TOKEN;
+    isEnPassant(col, row) {
+        return this.#boardState[col][row] == EN_PASSANT_TOKEN;
     }
 
+    // ================================================================
+    // En Passant Token Management (Adding & Deletion)
+
     // Add en passant token to coordinate & log coordinate
-    addEnPassantToken(col,row)
-    {
-        this.#boardState[col][row]=EN_PASSANT_TOKEN;
-        this.#enPassantCoordinate=[col,row];
+    addEnPassantToken(col, row) {
+        this.#boardState[col][row] = EN_PASSANT_TOKEN;
+        this.#enPassantCoordinate = [col, row];
     }
 
     // Destroy en passant token (if it exists)
-    destroyEnPassantToken()
-    {
-        if (this.#enPassantCoordinate)
-        {
-            let col=this.#enPassantCoordinate[0];
-            let row=this.#enPassantCoordinate[1];
-            this.#boardState[col][row]=null;
-            this.#enPassantCoordinate=null;
+    destroyEnPassantToken() {
+        if (this.#enPassantCoordinate) {
+            let col = this.#enPassantCoordinate[0];
+            let row = this.#enPassantCoordinate[1];
+            this.#boardState[col][row] = null;
+            this.#enPassantCoordinate = null;
         }
 
     }
 
+    // ================================================================
+    // Chess Piece Management (Adding & Moving & Destruction)
+
     // Add piece of chosen rank & alignment to coordinate
-    addPiece(col,row,rank,alignment)
-    {
-        this.#boardState[col][row] = new ChessPiece(this.#scene, X_ANCHOR+col*TILE_SIZE, Y_ANCHOR+row*TILE_SIZE, rank, alignment);
+    addPiece(col, row, rank, alignment) {
+        this.#boardState[col][row] = new ChessPiece(
+            this.#scene,
+            X_ANCHOR + col * TILE_SIZE,
+            Y_ANCHOR + row * TILE_SIZE,
+            rank,
+            alignment
+        );
         this.#scene.add.existing(this.#boardState[col][row]);
     }
 
     // Move piece in input coordinate to output coordinate
-    movePiece(input,output)
-    {
-        let incol=input[0];
-        let inrow=input[1];
-        let outcol=output[0];
-        let outrow=output[1];
+    movePiece(input, output) {
+        let incol = input[0];
+        let inrow = input[1];
+        let outcol = output[0];
+        let outrow = output[1];
 
         this.destroyEnPassantToken();
-        if (this.getRank(incol,inrow)==PAWN && Math.abs(inrow-outrow)==2)
-            this.addEnPassantToken(incol,(inrow+outrow)/2);
+        if (this.getRank(incol, inrow) == PAWN && Math.abs(inrow - outrow) == 2)
+            this.addEnPassantToken(incol, (inrow + outrow) / 2);
 
-        this.#boardState[incol][inrow].setPosition(X_ANCHOR+outcol*TILE_SIZE, Y_ANCHOR+outrow*TILE_SIZE);
+        this.#boardState[incol][inrow].setPosition(X_ANCHOR + outcol * TILE_SIZE, Y_ANCHOR + outrow * TILE_SIZE);
         this.#boardState[outcol][outrow] = this.#boardState[incol][inrow];
         this.#boardState[incol][inrow] = null;
     }
 
     // Completely destroy the piece
-    destroyPiece(col,row)
-    {
+    destroyPiece(col, row) {
         this.#boardState[col][row].destroy();
-        this.#boardState[col][row]=null;
+        this.#boardState[col][row] = null;
     }
 
+    // ================================================================
+    // Chess Piece Info (Alignment & Rank) Retrieval
+
     // Get alignment info of piece
-    getAlignment(col,row)
-    {
+    getAlignment(col, row) {
         return this.#boardState[col][row].getAlignment();
     }
 
     // Get rank info of piece
-    getRank(col,row)
-    {
+    getRank(col, row) {
         return this.#boardState[col][row].getRank();
     }
 
-    // Search for possible moves a piece can make
-    searchMoves(col,row)
-    {
-        let rank = this.getRank(col,row);
-        switch (rank)
-        {
+    // Check whether coordinate has different alignment
+    isDiffAlignment(col, row, alignment) {
+        return alignment != this.getAlignment(col, row);
+    }
+
+    // ================================================================
+    // Chess Piece Possible Moves Search
+
+    // Search for possible moves a chess piece can make
+    searchMoves(col, row) {
+        let rank = this.getRank(col, row);
+        switch (rank) {
             case PAWN:
-                return this.searchPawn(col,row);
+                return this.searchPawn(col, row);
             case ROOK:
-                return this.searchRook(col,row);
+                return this.searchRook(col, row);
             case KNIGHT:
-                return this.searchKnight(col,row);
+                return this.searchKnight(col, row);
             case BISHOP:
-                return this.searchBishop(col,row);
+                return this.searchBishop(col, row);
             case QUEEN:
-                return this.searchQueen(col,row);
+                return this.searchQueen(col, row);
             case KING:
-                return this.searchKing(col,row);
+                return this.searchKing(col, row);
         }
     }
 
     // Search for possible moves a pawn can make
-    searchPawn(col,row)
-    {
-        let moves=[];
-        let alignment=this.getAlignment(col,row);
-        let j = row + (alignment==PLAYER ? -1 : 1);
-        
-        for (let i=col-1;i<=col+1;i++)
-            if (this.isValid(i,j))
-            {
-                if (i==col && !this.isOccupied(i,j))
-                    moves.push({'xy':[i,j],'isEnemy':false});
-                else if (i!=col && this.isOccupied(i,j) && alignment!=this.getAlignment(i,j))
-                    moves.push({'xy':[i,j],'isEnemy':true});
-                else if (i!=col && this.isEnPassant(i,j) && this.isOccupied(i,row) && alignment!=this.getAlignment(i,row))
-                    moves.push({'xy':[i,j],'isEnemy':true});
+    searchPawn(col, row) {
+        let moves = [];
+        let alignment = this.getAlignment(col, row);
+        let j = row + (alignment == PLAYER ? -1 : 1);
+
+        for (let i = col - 1; i <= col + 1; i++)
+            if (this.isValid(i, j)) {
+                if (i == col && !this.isOccupied(i, j))
+                    moves.push({ xy: [i, j], isEnemy: false });
+                else if (i != col && this.isOccupied(i, j) && this.isDiffAlignment(i, j, alignment))
+                    moves.push({ xy: [i, j], isEnemy: true });
+                else if (i != col && this.isEnPassant(i, j) && this.isOccupied(i, row) && this.isDiffAlignment(i, row, alignment))
+                    moves.push({ xy: [i, j], isEnemy: true });
             }
-        
-        j += (alignment==PLAYER ? -1 : 1);
-        if (((j==3 && alignment==COMPUTER) || (j==4 && alignment==PLAYER)) && !this.isOccupied(col,j))
-            moves.push({'xy':[col,j],'isEnemy':false});
-        
+
+        j += (alignment == PLAYER ? -1 : 1);
+        if (((j == 3 && alignment == COMPUTER) || (j == 4 && alignment == PLAYER)) && !this.isOccupied(col, j))
+            moves.push({ xy: [col, j], isEnemy: false });
+
         return moves;
     }
 
     // Search for possible moves a knight can make
-    searchKnight(col,row)
-    {
-        let moves=[];
-        let alignment=this.getAlignment(col,row);
-        let x_s=[1,1,-1,-1,2,2,-2,-2];
-        let y_s=[2,-2,2,-2,1,-1,1,-1];
-        let x,y;
+    searchKnight(col, row) {
+        let moves = [];
+        let alignment = this.getAlignment(col, row);
+        let x_s = [1, 1, -1, -1, 2, 2, -2, -2];
+        let y_s = [2, -2, 2, -2, 1, -1, 1, -1];
+        let x, y;
 
-        for (let i=0;i<8;i++)
-        {
-            x=col+x_s[i];
-            y=row+y_s[i];
-            if (this.isValid(x,y))
-            {
-                if (!this.isOccupied(x,y))
-                    moves.push({'xy':[x,y],'isEnemy':false});
-                else if (alignment!=this.getAlignment(x,y))
-                    moves.push({'xy':[x,y],'isEnemy':true});
-            }
+        for (let i = 0; i < 8; i++) {
+            x = col + x_s[i];
+            y = row + y_s[i];
+            if (this.isValid(x, y))
+                this.searchTile(x, y, alignment, moves);
         }
 
         return moves;
     }
 
     // Search for possible moves a king can make
-    searchKing(col,row)
-    {
-        let moves=[];
-        let alignment=this.getAlignment(col,row);
+    searchKing(col, row) {
+        let moves = [];
+        let alignment = this.getAlignment(col, row);
 
-        for (let i=col-1;i<=col+1;i++)
-            for (let j=row-1;j<=row+1;j++)
-                if (this.isValid(i,j))
-                {
-                    if (!this.isOccupied(i,j))
-                        moves.push({'xy':[i,j],'isEnemy':false});
-                    else if (alignment!=this.getAlignment(i,j))
-                        moves.push({'xy':[i,j],'isEnemy':true});
-                }
-        
+        for (let i = col - 1; i <= col + 1; i++)
+            for (let j = row - 1; j <= row + 1; j++)
+                if (this.isValid(i, j))
+                    this.searchTile(i, j, alignment, moves);
+
         return moves;
     }
 
     // Search for possible moves a rook can make
-    searchRook(col,row)
-    {
-        let moves=[];
-        let alignment=this.getAlignment(col,row);
-        let i,j;
+    searchRook(col, row) {
+        let moves = [];
+        let alignment = this.getAlignment(col, row);
+        let i, j;
 
         // left
-        for (i=col-1; i>=0; i--)
-            if(!this.isOccupied(i,row))
-                moves.push({'xy':[i,row],'isEnemy':false});
-            else 
-            {
-                if(alignment!=this.getAlignment(i,row))
-                    moves.push({'xy':[i,row],'isEnemy':true});
+        for (i = col - 1; i >= 0; i--)
+            if (this.searchTile(i, row, alignment, moves))
                 break;
-            }
 
         // right
-        for (i=col+1; i<8; i++)
-            if(!this.isOccupied(i,row))
-                moves.push({'xy':[i,row],'isEnemy':false});
-            else 
-            {
-                if(alignment!=this.getAlignment(i,row))
-                    moves.push({'xy':[i,row],'isEnemy':true});
+        for (i = col + 1; i < 8; i++)
+            if (this.searchTile(i, row, alignment, moves))
                 break;
-            }
 
         // top
-        for (j=row-1; j>=0; j--)
-            if(!this.isOccupied(col,j))
-                moves.push({'xy':[col,j],'isEnemy':false});
-            else 
-            {
-                if(alignment!=this.getAlignment(col,j))
-                    moves.push({'xy':[col,j],'isEnemy':true});
+        for (j = row - 1; j >= 0; j--)
+            if (this.searchTile(col, j, alignment, moves))
                 break;
-            }
 
         // bottom
-        for (j=row+1; j<8; j++)
-            if(!this.isOccupied(col,j))
-                moves.push({'xy':[col,j],'isEnemy':false});
-            else 
-            {
-                if(alignment!=this.getAlignment(col,j))
-                    moves.push({'xy':[col,j],'isEnemy':true});
+        for (j = row + 1; j < 8; j++)
+            if (this.searchTile(col, j, alignment, moves))
                 break;
-            }
 
         return moves;
     }
 
     // Search for possible moves a bishop can make
-    searchBishop(col,row)
-    {
-        let moves=[];
-        let alignment=this.getAlignment(col,row);
-        let i,j;
+    searchBishop(col, row) {
+        let moves = [];
+        let alignment = this.getAlignment(col, row);
+        let i, j;
 
         // top left
-        for (i=col-1,j=row-1; i>=0&&j>=0; i--,j--)
-            if(!this.isOccupied(i,j))
-                moves.push({'xy':[i,j],'isEnemy':false});
-            else 
-            {
-                if(alignment!=this.getAlignment(i,j))
-                    moves.push({'xy':[i,j],'isEnemy':true});
+        for (i = col - 1, j = row - 1; i >= 0 && j >= 0; i--, j--)
+            if (this.searchTile(i, j, alignment, moves))
                 break;
-            }
 
         // top right
-        for (i=col+1,j=row-1; i<8&&j>=0; i++,j--)
-            if(!this.isOccupied(i,j))
-                moves.push({'xy':[i,j],'isEnemy':false});
-            else 
-            {
-                if(alignment!=this.getAlignment(i,j))
-                    moves.push({'xy':[i,j],'isEnemy':true});
+        for (i = col + 1, j = row - 1; i < 8 && j >= 0; i++, j--)
+            if (this.searchTile(i, j, alignment, moves))
                 break;
-            }
 
         // bottom left
-        for (i=col-1,j=row+1; i>=0&&j<8; i--,j++)
-            if(!this.isOccupied(i,j))
-                moves.push({'xy':[i,j],'isEnemy':false});
-            else 
-            {
-                if(alignment!=this.getAlignment(i,j))
-                    moves.push({'xy':[i,j],'isEnemy':true});
+        for (i = col - 1, j = row + 1; i >= 0 && j < 8; i--, j++)
+            if (this.searchTile(i, j, alignment, moves))
                 break;
-            }
 
         // bottom right
-        for (i=col+1,j=row+1; i<8&&j<8; i++,j++)
-            if(!this.isOccupied(i,j))
-                moves.push({'xy':[i,j],'isEnemy':false});
-            else 
-            {
-                if(alignment!=this.getAlignment(i,j))
-                    moves.push({'xy':[i,j],'isEnemy':true});
+        for (i = col + 1, j = row + 1; i < 8 && j < 8; i++, j++)
+            if (this.searchTile(i, j, alignment, moves))
                 break;
-            }
 
         return moves;
     }
 
     // Search for possible moves a queen can make
-    searchQueen(col,row)
-    {
-        return this.searchRook(col,row).concat(this.searchBishop(col,row));
+    searchQueen(col, row) {
+        return this.searchRook(col, row).concat(this.searchBishop(col, row));
+    }
+
+    searchTile(col, row, alignment, moves) {
+        if (!this.isOccupied(col, row))
+            moves.push({ xy: [col, row], isEnemy: false });
+        else {
+            if (this.isDiffAlignment(col, row, alignment))
+                moves.push({ xy: [col, row], isEnemy: true });
+            return true;
+        }
+
+        return false;
+    }
+
+    // ================================================================
+    // Chess Piece Possible Threats Seek
+
+    // Seek for possible threats to a hypothetical chess piece at a coordinate & of an alignment
+    // Whilst Optionally ignoring occupancy of a coordinate (mostly for when moving pieces)
+    seekThreats(col, row, alignment, ignoreTile = null) {
+        return []
+            .concat(this.seekAdjacent(col, row, alignment))
+            .concat(this.seekSkewed(col, row, alignment))
+            .concat(this.seekOrthogonal(col, row, alignment, ignoreTile = ignoreTile))
+            .concat(this.seekDiagonal(col, row, alignment, ignoreTile = ignoreTile));
+    }
+
+    // Seek for possible adjacent threats (pawns & kings)
+    seekAdjacent(col, row, alignment) {
+        let threats = [];
+
+        for (let i = col - 1; i <= col + 1; i++)
+            for (let j = row - 1; j <= row + 1; j++)
+                if (this.isValid(i, j) && this.isOccupied(i, j) && this.isDiffAlignment(i, j, alignment) && (i != col || j != row)) {
+                    let rank = this.getRank(i, j);
+                    switch (rank) {
+                        case PAWN:
+                            if ((alignment == PLAYER && j == row - 1 && i != col) || (alignment == COMPUTER && j == row + 1 && i != col))
+                                threats.push([i, j]);
+                            break;
+                        case KING:
+                            threats.push([i, j]);
+                            break;
+                    }
+                }
+
+        return threats;
+    }
+
+    // Seek for possible skewed threats (knights)
+    seekSkewed(col, row, alignment) {
+        let threats = [];
+
+        let x_s = [1, 1, -1, -1, 2, 2, -2, -2];
+        let y_s = [2, -2, 2, -2, 1, -1, 1, -1];
+        let x, y;
+
+        for (let i = 0; i < 8; i++) {
+            x = col + x_s[i];
+            y = row + y_s[i];
+            if (this.isValid(x, y))
+                this.seekTile(x, y, alignment, threats, KNIGHT);
+        }
+
+        return threats;
+    }
+
+    // Seek for possible orthogonal threats (rooks & queens)
+    seekOrthogonal(col, row, alignment, ignoreTile = null) {
+        let threats = [];
+
+        let i, j;
+
+        // left
+        for (i = col - 1; i >= 0; i--)
+            if (this.seekTile(i, row, alignment, threats, ROOK, ignoreTile = ignoreTile))
+                break;
+
+        // right
+        for (i = col + 1; i < 8; i++)
+            if (this.seekTile(i, row, alignment, threats, ROOK, ignoreTile = ignoreTile))
+                break;
+
+        // top
+        for (j = row - 1; j >= 0; j--)
+            if (this.seekTile(col, j, alignment, threats, ROOK, ignoreTile = ignoreTile))
+                break;
+
+        // bottom
+        for (j = row + 1; j < 8; j++)
+            if (this.seekTile(col, j, alignment, threats, ROOK, ignoreTile = ignoreTile))
+                break;
+
+        return threats;
+    }
+
+    // Seek for possible diagonal threats (bishops & queens)
+    seekDiagonal(col, row, alignment, ignoreTile = null) {
+        let threats = [];
+
+        let i, j;
+
+        // top left
+        for (i = col - 1, j = row - 1; i >= 0 && j >= 0; i--, j--)
+            if (this.seekTile(i, j, alignment, threats, BISHOP, ignoreTile = ignoreTile))
+                break;
+
+        // top right
+        for (i = col + 1, j = row - 1; i < 8 && j >= 0; i++, j--)
+            if (this.seekTile(i, j, alignment, threats, BISHOP, ignoreTile = ignoreTile))
+                break;
+
+        // bottom left
+        for (i = col - 1, j = row + 1; i >= 0 && j < 8; i--, j++)
+            if (this.seekTile(i, j, alignment, threats, BISHOP, ignoreTile = ignoreTile))
+                break;
+
+        // bottom right
+        for (i = col + 1, j = row + 1; i < 8 && j < 8; i++, j++)
+            if (this.seekTile(i, j, alignment, threats, BISHOP, ignoreTile = ignoreTile))
+                break;
+
+        return threats;
+    }
+
+    // Check whether a coordinate is a threat
+    seekTile(col, row, alignment, threats, compareRank, ignoreTile = null) {
+        if (this.isOccupied(col, row, ignoreTile = ignoreTile)) {
+            let rank = this.getRank(col, row);
+            let isThreat = rank == compareRank || ((compareRank == ROOK || compareRank == BISHOP) && rank == QUEEN);
+            if (this.isDiffAlignment(col, row, alignment) && isThreat)
+                threats.push([col, row]);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/game-objects/chess-piece.js
+++ b/src/game-objects/chess-piece.js
@@ -1,20 +1,18 @@
 export class ChessPiece extends Phaser.GameObjects.Image {
     #rank;
     #alignment;
-    
+
     constructor(scene, x, y, rank, alignment) {
-        super(scene, x, y, rank+alignment);
+        super(scene, x, y, rank + alignment);
         this.#rank = rank;
         this.#alignment = alignment;
     }
 
-    getRank()
-    {
+    getRank() {
         return this.#rank;
     }
 
-    getAlignment()
-    {
+    getAlignment() {
         return this.#alignment;
     }
 }  

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -1,8 +1,9 @@
 import { TILE_SIZE, X_ANCHOR, Y_ANCHOR } from "./constants";
-import { GRAY, FAWN, MAHOGANY, VIOLET, MAGNETA, DARK_GREY } from "./constants";
+import { HOVER_COLOR, WHITE_TILE_COLOR, BLACK_TILE_COLOR, NON_LETHAL_COLOR, LETHAL_COLOR, THREAT_COLOR, STAGE_COLOR } from "./constants";
 import { PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING } from "./constants";
 import { PLAYER, COMPUTER } from "./constants";
 import { BoardState } from "./board-state";
+import { isSamePoint } from "./constants";
 
 import { DEV_MODE } from "./constants";
 
@@ -10,21 +11,23 @@ export class ChessTiles {
     constructor(scene) {
         this.scene = scene;
 
-        this.chessTiles = []; // 8x8 array of chess tiles
-        this.boardState; // contains BoardState object that manages an 8x8 array of chess pieces
-        this.xy; // coordinate of selected chess piece; list of [i,j]
-        this.moves; // possible moves of selected chess piece; list of dictionaries of {'xy':[#,#],'isEnemy':boolean}
-        let temp; // temporary storage of coordinate & color; dictionary of {'xy':[i,j],'color':color}
+        this.chessTiles = [];   // 8x8 array of chess tiles
+        this.boardState;        // contains BoardState object that manages an 8x8 array of chess pieces
+        this.xy;                // coordinate of selected chess piece; list of [i,j]
+        this.moves;             // possible moves of selected chess piece; list of dictionaries of {'xy':[#,#],'isEnemy':boolean}
+        this.temp;              // temporary storage of coordinate & color; list of dictionaries of {'xy':[#,#],'color':color}
+        this.threats;           // temporary storage of threats to chess piece, list of lists of [#,#]
 
+        // Set up stage behind (surrounding) chessboard
         this.scene.add.rectangle(
             X_ANCHOR + 3.5 * TILE_SIZE,
             Y_ANCHOR + 3.5 * TILE_SIZE,
             9 * TILE_SIZE,
             9 * TILE_SIZE,
-            DARK_GREY
+            STAGE_COLOR
         );
 
-        // set up chessTiles & pointer behaviour, as well as interaction with pieces
+        // Set up chessTiles & pointer behaviour, as well as interaction with pieces
         for (let i = 0; i < 8; i++) {
             this.chessTiles.push([]);
             for (let j = 0; j < 8; j++) {
@@ -40,123 +43,144 @@ export class ChessTiles {
 
                 // When the pointer hovers over a tile, highlight it
                 this.chessTiles[i][j].on("pointerover", () => {
+                    // if highlighted as possible move, save state to restore on pointerout
                     let color = this.chessTiles[i][j].fillColor;
-                    if (color == VIOLET || color == MAGNETA)
-                        // if highlighted as possible move, save state to restore on pointerout
-                        temp = { xy: [i, j], color: color };
-                    this.highlightColor([i, j], GRAY);
+                    if (color == NON_LETHAL_COLOR || color == LETHAL_COLOR)
+                        this.temp = [{ xy: [i, j], color: color }];
+
+                    // highlight tile
+                    this.highlightColor([i, j], HOVER_COLOR);
+
+                    // if hovering over a piece and either 1. is selected piece or 2. no piece is selected, highlight this.threats
+                    if ((!this.xy || isSamePoint(this.xy, [i, j])) && this.boardState.isOccupied(i, j)) {
+                        this.threats = this.boardState.seekThreats(i, j, this.boardState.getAlignment(i, j))
+                        if (!this.temp)
+                            this.temp = [];
+                        for (let tile of this.threats) {
+                            let colo = this.chessTiles[tile[0]][tile[1]].fillColor;
+                            if (colo == NON_LETHAL_COLOR || colo == LETHAL_COLOR)
+                                this.temp.push({ xy: tile, color: colo });
+                            this.highlightColor(tile, THREAT_COLOR);
+                        }
+                    }
                 });
 
                 // When the pointer moves away from a tile, restore original color
                 this.chessTiles[i][j].on("pointerout", () => {
-                    if (!this.xy || this.xy[0] != i || this.xy[1] != j)
-                        // if tile isn't selected
+                    // restore non-selected tiles to board color
+                    if (!this.xy || !isSamePoint(this.xy, [i, j]))
                         this.restoreColor([i, j]);
-                    if (temp)
-                        // restore highlighted tile color
-                        this.highlightColor(temp.xy, temp.color);
+
+                    // restore highlighted lethal / non-lethal tile colors, if selected piece exists
+                    if (this.temp)
+                        for (let tile of this.temp)
+                            this.highlightColor(tile.xy, tile.color);
+
+                    // restore highlighted this.threats to board color, unless already restored to lethal / non-lethal tile colors
+                    if (this.threats && (!this.temp || this.temp.length != 1))
+                        for (let tile of this.threats)
+                            this.restoreColor(tile);
+
+                    this.temp = null;
+                    this.threats = null;
                 });
 
                 // When the pointer pushes down a tile, select/move piece & highlight selected tile / possible moves
                 this.chessTiles[i][j].on("pointerdown", () => {
-                    if (this.xy && this.xy[0] == i && this.xy[1] == j)
-                        // if tile is same as selected, unselect piece
+                    // if tile is same as selected, unselect piece
+                    if (this.xy && isSamePoint(this.xy, [i, j]))
                         this.clearBoard();
+                    // else if tile is occupied re-select new piece or move & eliminate piece
                     else if (this.boardState.isOccupied(i, j))
-                        // else if tile is occupied
                         switch (this.boardState.getAlignment(i, j)) {
                             case PLAYER: // if PLAYER's piece
-                                if (this.xy)
-                                    // if previously selected piece exists, restore corresponding tile to original color
-                                    this.clearBoard();
-                                this.highlightColor([i, j], GRAY);
+                                this.clearBoard();
+
+                                // highlight tile & possible moves & record selected piece into xy
+                                this.highlightColor([i, j], HOVER_COLOR);
                                 this.moves = this.boardState.searchMoves(i, j);
                                 for (let move of this.moves)
                                     this.highlightColor(
                                         move.xy,
-                                        move.isEnemy ? MAGNETA : VIOLET
+                                        move.isEnemy ? LETHAL_COLOR : NON_LETHAL_COLOR
                                     );
                                 this.xy = [i, j];
                                 break;
                             case COMPUTER: // if COMPUTER's piece
+                                // if previously selected piece exists & move is valid, destroy then move piece
                                 if (this.xy && this.isValidMove([i, j])) {
-                                    // if previously selected piece exists & move is valid, destroy then move piece
                                     this.boardState.destroyPiece(i, j);
                                     this.boardState.movePiece(this.xy, [i, j]);
                                     this.clearBoard();
                                 }
                                 break;
                         }
+                    // if not occupied & move is valid, move piece
                     else if (this.xy && this.isValidMove([i, j])) {
-                        // if not occupied & move is valid, move piece
+                        // if en passant move, destroy enemy pawn
                         if (
-                            this.boardState.getRank(this.xy[0], this.xy[1]) ==
-                                PAWN &&
+                            this.boardState.getRank(this.xy[0], this.xy[1]) == PAWN &&
                             this.boardState.isEnPassant(i, j)
                         )
-                            // if en passant move, destroy enemy pawn
                             this.boardState.destroyPiece(i, this.xy[1]);
+
+                        // move piece & clear board
                         this.boardState.movePiece(this.xy, [i, j]);
                         this.clearBoard();
                     }
 
-                    temp = null;
+                    this.temp = null;
+                    this.threats = null;
                 });
 
                 // if DEV_MODE is enabled; Enable COMPUTER moves via substituting pointerdown with scrolling
                 if (DEV_MODE)
                     // When the pointer scrolls on a tile, select/move piece & highlight selected tile / possible moves
                     this.chessTiles[i][j].on("wheel", () => {
-                        if (this.xy && this.xy[0] == i && this.xy[1] == j)
-                            // if tile is same as selected, unselect piece
+                        // if tile is same as selected, unselect piece
+                        if (this.xy && isSamePoint(this.xy, [i, j]))
                             this.clearBoard();
+                        // else if tile is occupied re-select new piece or move & eliminate piece
                         else if (this.boardState.isOccupied(i, j))
-                            // else if tile is occupied
                             switch (this.boardState.getAlignment(i, j)) {
                                 case COMPUTER: // if COMPUTER's piece
-                                    if (this.xy)
-                                        // if previously selected piece exists, restore corresponding tile to original color
-                                        this.clearBoard();
-                                    this.highlightColor([i, j], GRAY);
-                                    this.moves = this.boardState.searchMoves(
-                                        i,
-                                        j
-                                    );
+                                    this.clearBoard();
+
+                                    // highlight tile & possible moves & record selected piece into xy
+                                    this.highlightColor([i, j], HOVER_COLOR);
+                                    this.moves = this.boardState.searchMoves(i, j);
                                     for (let move of this.moves)
                                         this.highlightColor(
                                             move.xy,
-                                            move.isEnemy ? MAGNETA : VIOLET
+                                            move.isEnemy ? LETHAL_COLOR : NON_LETHAL_COLOR
                                         );
                                     this.xy = [i, j];
                                     break;
                                 case PLAYER: // if PLAYER's piece
+                                    // if previously selected piece exists & move is valid, destroy then move piece
                                     if (this.xy && this.isValidMove([i, j])) {
-                                        // if previously selected piece exists & move is valid, destroy then move piece
                                         this.boardState.destroyPiece(i, j);
-                                        this.boardState.movePiece(this.xy, [
-                                            i,
-                                            j,
-                                        ]);
+                                        this.boardState.movePiece(this.xy, [i, j]);
                                         this.clearBoard();
                                     }
                                     break;
                             }
+                        // if not occupied & move is valid, move piece
                         else if (this.xy && this.isValidMove([i, j])) {
-                            // if not occupied & move is valid, move piece
+                            // if en passant move, destroy enemy pawn
                             if (
-                                this.boardState.getRank(
-                                    this.xy[0],
-                                    this.xy[1]
-                                ) == PAWN &&
+                                this.boardState.getRank(this.xy[0], this.xy[1]) == PAWN &&
                                 this.boardState.isEnPassant(i, j)
                             )
-                                // if en passant move, destroy enemy pawn
                                 this.boardState.destroyPiece(i, this.xy[1]);
+
+                            // move piece & clear board
                             this.boardState.movePiece(this.xy, [i, j]);
                             this.clearBoard();
                         }
 
-                        temp = null;
+                        this.temp = null;
+                        this.threats = null;
                     });
             }
         }
@@ -166,32 +190,40 @@ export class ChessTiles {
 
     // Highlight selected tile
     highlightColor([col, row], color) {
-        this.chessTiles[col][row].setFillStyle(color); // Ensure color is passed correctly
+        this.chessTiles[col][row].setFillStyle(color);
     }
 
     // Restore original tile color
     restoreColor([col, row]) {
-        this.chessTiles[col][row].setFillStyle(this.getTileColor([col, row])); // Ensure this returns the correct color
+        this.chessTiles[col][row].setFillStyle(this.getTileColor([col, row]));
     }
 
     // Restore original tile color
     clearBoard() {
-        this.restoreColor(this.xy);
-        for (let move of this.moves) this.restoreColor(move.xy);
+        if (this.xy)
+            this.restoreColor(this.xy);
+        if (this.moves)
+            for (let move of this.moves)
+                this.restoreColor(move.xy);
+        if (this.threats)
+            for (let tile of this.threats)
+                this.restoreColor(tile);
         this.xy = null;
         this.moves = null;
     }
 
     // Get original tile color
     getTileColor([col, row]) {
-        return (col + row) % 2 == 0 ? FAWN : MAHOGANY;
+        return (col + row) % 2 == 0 ? WHITE_TILE_COLOR : BLACK_TILE_COLOR;
     }
 
     // Check whether the coordinate would be a valid move
     isValidMove([col, row]) {
-        if (!this.moves) return false;
+        if (!this.moves)
+            return false;
         for (let move of this.moves)
-            if (move.xy[0] == col && move.xy[1] == row) return true;
+            if (move.xy[0] == col && move.xy[1] == row)
+                return true;
         return false;
     }
 }

--- a/src/game-objects/constants.js
+++ b/src/game-objects/constants.js
@@ -1,42 +1,65 @@
-const TILE_SIZE = 80; // width & height of each tile
-const X_ANCHOR = 512 - 3.5 * TILE_SIZE; // leftmost pixel of chess board
-const Y_ANCHOR = 384 - 3.5 * TILE_SIZE; // topmost pixel of chess board
+const TILE_SIZE = 80;                       // width & height of each tile
+const X_ANCHOR = 512 - 3.5 * TILE_SIZE;     // x pixel of leftmost tile
+const Y_ANCHOR = 384 - 3.5 * TILE_SIZE;     // y pixel of topmost tile
 
-const GRAY = "0x7D7F7C"; // highlight color
-const FAWN = "0xE5AA70"; // white color
-const MAHOGANY = "0xC04000"; // black color
-const ONYX = "0x3B3B3B"; //deep gray color
-const CREAM = "0xF4FFFD"; //whiteish color
-const GREEN = "0x6E9075"; // green color
-const VIOLET = "0x7F00FF"; // non-lethal color
-const MAGNETA = "0xFF00FF"; // lethal color
-const DARK_GREY = "0x3b3b3b"; // stage color
+const GRAY = "7D7F7C";
+const FAWN = "E5AA70";
+const MAHOGANY = "C04000";
+const VIOLET = "7F00FF";
+const MAGNETA = "FF00FF";
+const AZURE = "007FFF";
+const DARK_GREY = "3B3B3B";
 
-const FAWNHEX = "#E5AA70"; // fawn color hex
-const MAHOGANYHEX = "#C04000"; // mahogany color hex
-const ONYXHEX = "#3B3B3B"; // deep gray color hex
-const CREAMHEX = "#F4FFFD"; // whitish color hex
-const GREENHEX = "#6E9075"; // green color hex
+const ONYX = "3B3B3B";
+const CREAM = "F4FFFD";
+const GREEN = "6E9075";
 
-const PAWN = "pawn"; // pawn rank
-const ROOK = "rook"; // rook rank
-const KNIGHT = "knight"; // knight rank
-const BISHOP = "bishop"; // bishop rank
-const QUEEN = "queen"; // queen rank
-const KING = "king"; // king rank
+const ZEROX = "0x";
+const HASH = "#";
 
-const PLAYER = "W"; // player alignment
-const COMPUTER = "B"; // computer alignment
+const HOVER_COLOR = ZEROX + GRAY;           // hover color
+const WHITE_TILE_COLOR = ZEROX + FAWN;      // white tile color
+const BLACK_TILE_COLOR = ZEROX + MAHOGANY;  // black tile color
+const NON_LETHAL_COLOR = ZEROX + VIOLET;    // non-lethal move color
+const LETHAL_COLOR = ZEROX + MAGNETA;       // lethal move color
+const THREAT_COLOR = ZEROX + AZURE;         // threat color
+const STAGE_COLOR = ZEROX + DARK_GREY;      // chessboard stage color
 
-const EN_PASSANT_TOKEN = "en passant"; // en passant token
+const BACKGROUND_COLOR = ZEROX + ONYX;
+
+const FAWNHEX = HASH + FAWN;                // fawn color hex
+const MAHOGANYHEX = HASH + MAHOGANY;        // mahogany color hex
+const ONYXHEX = HASH + ONYX;                // deep gray color hex
+const CREAMHEX = HASH + CREAM;              // whitish color hex
+const GREENHEX = HASH + GREEN;              // green color hex
+
+const PAWN = "pawn";                        // pawn rank
+const ROOK = "rook";                        // rook rank
+const KNIGHT = "knight";                    // knight rank
+const BISHOP = "bishop";                    // bishop rank
+const QUEEN = "queen";                      // queen rank
+const KING = "king";                        // king rank
+
+const PLAYER = "W";                         // player alignment
+const COMPUTER = "B";                       // computer alignment
+
+const EN_PASSANT_TOKEN = "en passant";      // en passant token
 
 const DEV_MODE = true; // enable development features; SET TO FALSE ON MAIN BRANCH
 
+export function isSamePoint([col1, row1], [col2, row2]) {
+    return col1 == col2 && row1 == row2;
+}
+
 export { TILE_SIZE, X_ANCHOR, Y_ANCHOR };
-export { GRAY, FAWN, MAHOGANY, ONYX, CREAM, GREEN, VIOLET, MAGNETA, DARK_GREY };
+
+export { HOVER_COLOR, WHITE_TILE_COLOR, BLACK_TILE_COLOR, NON_LETHAL_COLOR, LETHAL_COLOR, THREAT_COLOR, STAGE_COLOR };
+export { BACKGROUND_COLOR };
 export { FAWNHEX, MAHOGANYHEX, ONYXHEX, CREAMHEX, GREENHEX };
+
 export { PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING };
 export { PLAYER, COMPUTER };
 export { EN_PASSANT_TOKEN };
+
 export { DEV_MODE };
 

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -1,7 +1,7 @@
 import { Game as MainGame } from "./scenes/Game";
 import { Start as StartScene } from "./scenes/Start";
 import { AUTO, Game } from "phaser";
-import { ONYX } from "../game-objects/constants";
+import { BACKGROUND_COLOR } from "../game-objects/constants";
 
 //  Find out more information about the Game Config at:
 //  https://newdocs.phaser.io/docs/3.70.0/Phaser.Types.Core.GameConfig
@@ -10,7 +10,7 @@ const config = {
     width: 1024,
     height: 768,
     parent: "game-container",
-    backgroundColor: ONYX,
+    backgroundColor: BACKGROUND_COLOR,
     scene: [StartScene],
 };
 

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -1,16 +1,8 @@
 import { Scene } from "phaser";
 import { EventBus } from "../EventBus";
 
-import {
-    PAWN,
-    ROOK,
-    KNIGHT,
-    BISHOP,
-    QUEEN,
-    KING,
-    CREAMHEX,
-    ONYXHEX,
-} from "../../game-objects/constants";
+import { PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING } from "../../game-objects/constants";
+import { CREAMHEX, ONYXHEX } from "../../game-objects/constants";
 import { PLAYER, COMPUTER } from "../../game-objects/constants";
 import { ChessTiles } from "../../game-objects/chess-tiles";
 


### PR DESCRIPTION
1. Add threat detection wherein it is now possible the coordinates of the chess pieces that would threaten a hypothetical chess piece of a given coordinate & alignment whilst optionally ignoring occupancy in a tile.
2. Highlight chess pieces that is currently threatening the chess piece the cursor is hovering over.
3. Trim existing repetitive code in the search functions in board-state.js into a separate function (that is also used in the newly added threat methods).
4. Re-format all code (js files in game-objects folder) so that it matches the format you get when you Alt-Shift-F in VSCode.
5. Redesign color constants to be separated into 1. The actual colors that contain the hex value and 2. Variables with names that describe their purpose/usage that uses the aforementioned color variables.
6. Smooth chess piece interaction by immediate triggering the hover event once chess piece is placed.

(Main accomplishment is threat detection, which is necessary in castling since the king cannot pass through tiles where it would be threatened)

Related Issue(s)
#18 