### PR TITLE
Pawn Promotion

### DIFF
--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -5,8 +5,7 @@ import { PLAYER, COMPUTER } from "./constants";
 import { isSamePoint } from "./constants";
 import { DEV_MODE } from "./constants";
 import { BoardState } from "./board-state";
-// import { Scene } from "phaser";
-// import { EventBus } from "../EventBus";
+
 
 
 export class ChessTiles {
@@ -19,6 +18,8 @@ export class ChessTiles {
         this.moves;             // possible moves of selected chess piece; list of dictionaries of {'xy':[#,#],'isEnemy':boolean}
         this.temp;              // temporary storage of coordinate & color; list of dictionaries of {'xy':[#,#],'color':color}
         this.threats;           // temporary storage of threats to chess piece, list of lists of [#,#]
+        this.promotionCol;      // temporary storage of column of piece to promote
+        this.promotionRow;      // temporary storage of row of piece to promote
 
         // Set up stage behind (surrounding) chessboard
         this.scene.add.rectangle(
@@ -228,15 +229,14 @@ export class ChessTiles {
     checkPromotion([col, row]) {
         if (this.boardState.getAlignment(col, row)==PLAYER && this.boardState.getRank(col, row) == PAWN && row==0) {
             // do the promotion
-            console.log("Player promotion")
-            // let piece = 
             import("../game/scenes/Promotion") // Dynamically import the rules scene
             .then((module) => {
         // Only add the scene if it's not already registered
         if (!this.scene.scene.get("Promotion")) {
             this.scene.scene.add("Promotion", module.Promotion); // Add the scene dynamically
         }
-
+        this.promotionCol = col;
+        this.promotionRow = row;
         // Use launch to run scene in parallel to current
         this.scene.scene.launch("Promotion");
     });
@@ -244,22 +244,18 @@ export class ChessTiles {
         } else if (this.boardState.getAlignment(col, row)==COMPUTER && this.boardState.getRank(col, row) == PAWN && row==7) {
             // set black piece to queen which is almost always correct choice, 
             // ocassionally knight might be correct but this is less computationally intensive
-            this.boardState.destroyPiece(col,row); // might need update with capture
+            this.promotionCol = col;
+            this.promotionRow = row;
             this.boardState.addPiece(col,row,QUEEN,COMPUTER);
             
         }
     }
-    
-    // runPromotion() {
-    //     import("../game/scenes/Promotion") // Dynamically import the rules scene
-    //         .then((module) => {
-    //     // Only add the scene if it's not already registered
-    //     if (!this.scene.scene.get("Promotion")) {
-    //         this.scene.scene.add("Promotion", module.Promotion); // Add the scene dynamically
-    //     }
 
-    //     // Use launch to run scene in parallel to current
-    //     this.scene.scene.launch("Promotion");
-    // });}
+    setPromotion(rank, alignment) {
+        this.boardState.destroyPiece(this.promotionCol, this.promotionRow); // might need update with capture
+        this.boardState.addPiece(this.promotionCol, this.promotionRow, rank, alignment);
+        // this.promotionCol = null; // should be unnecessary to reinitialize
+        // this.promotionRow = null;
+    }
 }
 

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -5,6 +5,7 @@ import { PLAYER, COMPUTER } from "./constants";
 import { isSamePoint } from "./constants";
 import { DEV_MODE } from "./constants";
 import { BoardState } from "./board-state";
+import { EventBus } from "../game/EventBus";
 
 
 
@@ -238,6 +239,9 @@ export class ChessTiles {
         this.promotionCol = col;
         this.promotionRow = row;
         // Use launch to run scene in parallel to current
+        EventBus.once("PawnPromoted", (detail) => {
+            this.boardState.destroyPiece(this.promotionCol, this.promotionRow); // might need update with capture
+            this.boardState.addPiece(this.promotionCol, this.promotionRow, detail, PLAYER);});
         this.scene.scene.launch("Promotion");
     });
     
@@ -254,8 +258,7 @@ export class ChessTiles {
     setPromotion(rank, alignment) {
         this.boardState.destroyPiece(this.promotionCol, this.promotionRow); // might need update with capture
         this.boardState.addPiece(this.promotionCol, this.promotionRow, rank, alignment);
-        // this.promotionCol = null; // should be unnecessary to reinitialize
-        // this.promotionRow = null;
+        console.log("promotion!")
     }
 }
 

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -240,8 +240,8 @@ export class ChessTiles {
         this.promotionRow = row;
         // Use launch to run scene in parallel to current
         EventBus.once("PawnPromoted", (detail) => {
-            this.boardState.destroyPiece(this.promotionCol, this.promotionRow); // might need update with capture
-            this.boardState.addPiece(this.promotionCol, this.promotionRow, detail, PLAYER);});
+            // this.boardState.destroyPiece(this.promotionCol, this.promotionRow); // might need update with capture
+            this.setPromotion(detail, PLAYER);});
         this.scene.scene.launch("Promotion");
     });
     

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -250,15 +250,13 @@ export class ChessTiles {
             // ocassionally knight might be correct but this is less computationally intensive
             this.promotionCol = col;
             this.promotionRow = row;
-            this.boardState.addPiece(col,row,QUEEN,COMPUTER);
-            
+            this.setPromotion(QUEEN,COMPUTER);
         }
     }
 
     setPromotion(rank, alignment) {
         this.boardState.destroyPiece(this.promotionCol, this.promotionRow); // might need update with capture
         this.boardState.addPiece(this.promotionCol, this.promotionRow, rank, alignment);
-        console.log("promotion!")
     }
 }
 

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -230,7 +230,16 @@ export class ChessTiles {
             // do the promotion
             console.log("Player promotion")
             // let piece = 
-            this.runPromotion();
+            import("../game/scenes/Promotion") // Dynamically import the rules scene
+            .then((module) => {
+        // Only add the scene if it's not already registered
+        if (!this.scene.scene.get("Promotion")) {
+            this.scene.scene.add("Promotion", module.Promotion); // Add the scene dynamically
+        }
+
+        // Use launch to run scene in parallel to current
+        this.scene.scene.launch("Promotion");
+    });
     
         } else if (this.boardState.getAlignment(col, row)==COMPUTER && this.boardState.getRank(col, row) == PAWN && row==7) {
             // set black piece to queen which is almost always correct choice, 
@@ -241,16 +250,16 @@ export class ChessTiles {
         }
     }
     
-    runPromotion() {
-        import("../game/scenes/Promotion") // Dynamically import the rules scene
-            .then((module) => {
-        // Only add the scene if it's not already registered
-        if (!this.scene.get("Promotion")) {
-            this.scene.add("game/scenes/Promotion", module.Promotion); // Add the scene dynamically
-        }
+    // runPromotion() {
+    //     import("../game/scenes/Promotion") // Dynamically import the rules scene
+    //         .then((module) => {
+    //     // Only add the scene if it's not already registered
+    //     if (!this.scene.scene.get("Promotion")) {
+    //         this.scene.scene.add("Promotion", module.Promotion); // Add the scene dynamically
+    //     }
 
-        // Use launch to run scene in parallel to current
-        this.scene.launch("game/scenes/Promotion");
-    });}
+    //     // Use launch to run scene in parallel to current
+    //     this.scene.scene.launch("Promotion");
+    // });}
 }
 

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -5,6 +5,9 @@ import { PLAYER, COMPUTER } from "./constants";
 import { isSamePoint } from "./constants";
 import { DEV_MODE } from "./constants";
 import { BoardState } from "./board-state";
+// import { Scene } from "phaser";
+// import { EventBus } from "../EventBus";
+
 
 export class ChessTiles {
     constructor(scene) {
@@ -146,6 +149,9 @@ export class ChessTiles {
                     if (this.xy && this.isValidMove([i, j])) {
                         this.boardState.destroyPiece(i, j);
                         this.boardState.movePiece(this.xy, [i, j]);
+                        
+                        this.checkPromotion([i, j])
+                        
                         this.clearBoard();
                     }
                     break;
@@ -161,6 +167,9 @@ export class ChessTiles {
 
             // move piece & clear board
             this.boardState.movePiece(this.xy, [i, j]);
+
+            this.checkPromotion([i, j])
+
             this.clearBoard();
         }
         else
@@ -214,5 +223,34 @@ export class ChessTiles {
                 return true;
         return false;
     }
+
+    // check whether the move results in a promotion
+    checkPromotion([col, row]) {
+        if (this.boardState.getAlignment(col, row)==PLAYER && this.boardState.getRank(col, row) == PAWN && row==0) {
+            // do the promotion
+            console.log("Player promotion")
+            // let piece = 
+            this.runPromotion();
+    
+        } else if (this.boardState.getAlignment(col, row)==COMPUTER && this.boardState.getRank(col, row) == PAWN && row==7) {
+            // set black piece to queen which is almost always correct choice, 
+            // ocassionally knight might be correct but this is less computationally intensive
+            this.boardState.destroyPiece(col,row); // might need update with capture
+            this.boardState.addPiece(col,row,QUEEN,COMPUTER);
+            
+        }
+    }
+    
+    runPromotion() {
+        import("../game/scenes/Promotion") // Dynamically import the rules scene
+            .then((module) => {
+        // Only add the scene if it's not already registered
+        if (!this.scene.get("Promotion")) {
+            this.scene.add("game/scenes/Promotion", module.Promotion); // Add the scene dynamically
+        }
+
+        // Use launch to run scene in parallel to current
+        this.scene.launch("game/scenes/Promotion");
+    });}
 }
 

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -26,18 +26,6 @@ export class Game extends Scene {
 
     create() {
         this.add.image(512, 384, "background");
-        //         this.add.image(512, 350, "star").setDepth(100);
-        //         this.add
-        //             .text(512, 490, "You are currently playing the game", {
-        //                 fontFamily: "Arial Black",
-        //                 fontSize: 38,
-        //                 color: "#ffffff",
-        //                 stroke: "#000000",
-        //                 strokeThickness: 8,
-        //                 align: "center",
-        //             })
-        //             .setOrigin(0.5)
-        //             .setDepth(100);
 
         // 4 new files in src/game-objects
         // 6 sets of chess pieces (3 pairs of BW) in pubic/assets/drummyfish chess; Brought to you by Hope!

--- a/src/game/scenes/Promotion.js
+++ b/src/game/scenes/Promotion.js
@@ -14,7 +14,7 @@ export class Promotion extends Scene {
     }
 
     create() {
-        this.add.image(512, 384, "background").alpha = 0.0;
+        this.add.image(512, 384, "background").alpha = 0.5;
         this.add.image(512, 350, "star").setDepth(100);
         this.add
             .text(512, 490, "These are the rules", {

--- a/src/game/scenes/Promotion.js
+++ b/src/game/scenes/Promotion.js
@@ -8,6 +8,8 @@ import { ChessTiles } from "../../game-objects/chess-tiles";
 export class Promotion extends Scene {
     constructor() {
         super("Promotion");
+        this.rank;
+        this.alignment;
     }
 
     preload() {
@@ -39,21 +41,53 @@ export class Promotion extends Scene {
         const rook = this.add.image(bgX/2+150,bgY/2, "rook").setDepth(5).setScale(1.5);
         const pieces = [queen, bishop, knight, rook];
 
-        for (let piece in pieces) {
-            console.log("piece:" + piece)
-            pieces[piece].setInteractive();
-            pieces[piece].on(
-                "pointerdown",
-                function () {
-                    // console.log(this.scene.get("MainGame").children);
-                    console.log(ChessTiles);
-                    // ChessTiles.setPromotion(QUEEN,PLAYER);
-                    // this.scene.get("MainGame").scene.setPromotion(QUEEN,PLAYER);
-                    this.scene.stop("Promotion");
+        // Some sort of event listener maybe?
+        // const promotionEvent = new CustomEvent("PawnPromoted", {detail: { rank: this.rank}});
+
+        
+        queen.setInteractive();
+        queen.on(
+            "pointerdown",
+            function () {
+                // sends event telling promotion happened
+                EventBus.emit("PawnPromoted", QUEEN);
+                this.scene.stop("Promotion");
                 },
                 this
             );
-        };
+        
+        rook.setInteractive();
+        rook.on(
+            "pointerdown",
+            function () {
+                // sends event telling promotion happened
+                EventBus.emit("PawnPromoted", ROOK);
+                this.scene.stop("Promotion");
+                },
+                this
+        );
+
+        bishop.setInteractive();
+        bishop.on(
+            "pointerdown",
+            function () {
+                // sends event telling promotion happened
+                EventBus.emit("PawnPromoted", BISHOP);
+                this.scene.stop("Promotion");
+                },
+                this
+        );
+
+        knight.setInteractive();
+        knight.on(
+            "pointerdown",
+            function () {
+                // sends event telling promotion happened
+                EventBus.emit("PawnPromoted", KNIGHT);
+                this.scene.stop("Promotion");
+                },
+                this
+        );
 
         // Creates a visual background that also blocks input on the scene underneath
 

--- a/src/game/scenes/Promotion.js
+++ b/src/game/scenes/Promotion.js
@@ -1,0 +1,58 @@
+import { Scene } from "phaser";
+import { EventBus } from "../EventBus";
+
+export class Promotion extends Scene {
+    constructor() {
+        super("Promotion");
+    }
+
+    preload() {
+        this.load.setPath("assets");
+
+        this.load.image("star", "star.png");
+        this.load.image("background", "bg.png");
+    }
+
+    create() {
+        this.add.image(512, 384, "background").alpha = 0.0;
+        this.add.image(512, 350, "star").setDepth(100);
+        this.add
+            .text(512, 490, "These are the rules", {
+                fontFamily: "Arial Black",
+                fontSize: 38,
+                color: "#ffffff",
+                stroke: "#000000",
+                strokeThickness: 8,
+                align: "center",
+            })
+            .setOrigin(0.5)
+            .setDepth(100);
+
+        const closeButton = this.add.text(100, 100, "Close Rules", {
+            fill: "#0099ff",
+            backgroundColor: "#ffff",
+            padding: { left: 20, right: 20, top: 10, bottom: 10 },
+        });
+        closeButton.setPosition(425, 600);
+        closeButton.setInteractive();
+        closeButton.on(
+            "pointerdown",
+            function () {
+                this.scene.stop("Rules");
+            },
+            this
+        );
+
+        // When the pointer hovers over the button, scale it up
+        closeButton.on("pointerover", () => {
+            closeButton.setScale(1.2); // Increase the scale (grow the button by 20%)
+        });
+
+        // When the pointer moves away from the button, reset the scale to normal
+        closeButton.on("pointerout", () => {
+            closeButton.setScale(1); // Reset to original size
+        });
+
+        EventBus.emit("current-scene-ready", this);
+    }
+}

--- a/src/game/scenes/Promotion.js
+++ b/src/game/scenes/Promotion.js
@@ -1,6 +1,6 @@
 import { Scene } from "phaser";
 import { EventBus } from "../EventBus";
-import {QUEEN, BISHOP, ROOK, KNIGHT } from "../../game-objects/constants";
+import {QUEEN, BISHOP, ROOK, KNIGHT, X_ANCHOR, Y_ANCHOR, TILE_SIZE } from "../../game-objects/constants";
 
 export class Promotion extends Scene {
     constructor() {
@@ -9,10 +9,10 @@ export class Promotion extends Scene {
 
     preload() {
         this.load.setPath("assets/drummyfish chess/");
-        this.load.image("queen", "queenB.png");
-        this.load.image("knight", "knightB.png");
-        this.load.image("rook", "rookB.png");
-        this.load.image("bishop", "bishopB.png");
+        this.load.image("queen", "queenW.png");
+        this.load.image("knight", "knightW.png");
+        this.load.image("rook", "rookW.png");
+        this.load.image("bishop", "bishopW.png");
     }
 
     create() {
@@ -30,10 +30,10 @@ export class Promotion extends Scene {
             .setOrigin(0.5)
             .setDepth(100);
 
-        const queen = this.add.image(bgX/2-150,bgY/2, "queen").setDepth(5).setScale(1.5);
-        const bishop = this.add.image(bgX/2-50,bgY/2, "bishop").setDepth(5).setScale(1.5);
-        const knight = this.add.image(bgX/2+50,bgY/2, "knight").setDepth(5).setScale(1.5);
-        const rook = this.add.image(bgX/2+150,bgY/2, "rook").setDepth(5).setScale(1.5);
+        const queen = this.add.image(X_ANCHOR + 3.5 * TILE_SIZE-150, Y_ANCHOR + 3.5 * TILE_SIZE, "queen").setDepth(5).setScale(1.5);
+        const bishop = this.add.image(X_ANCHOR + 3.5 * TILE_SIZE-50, Y_ANCHOR + 3.5 * TILE_SIZE, "bishop").setDepth(5).setScale(1.5);
+        const knight = this.add.image(X_ANCHOR + 3.5 * TILE_SIZE+50, Y_ANCHOR + 3.5 * TILE_SIZE, "knight").setDepth(5).setScale(1.5);
+        const rook = this.add.image(X_ANCHOR + 3.5 * TILE_SIZE+150 ,Y_ANCHOR + 3.5 * TILE_SIZE, "rook").setDepth(5).setScale(1.5);
         const pieces = [queen, bishop, knight, rook];
 
         

--- a/src/game/scenes/Promotion.js
+++ b/src/game/scenes/Promotion.js
@@ -1,15 +1,10 @@
 import { Scene } from "phaser";
 import { EventBus } from "../EventBus";
 import {QUEEN, BISHOP, ROOK, KNIGHT } from "../../game-objects/constants";
-import {PLAYER, COMPUTER } from "../../game-objects/constants";
-import { Game } from "./Game";
-import { ChessTiles } from "../../game-objects/chess-tiles";
 
 export class Promotion extends Scene {
     constructor() {
         super("Promotion");
-        this.rank;
-        this.alignment;
     }
 
     preload() {
@@ -24,7 +19,7 @@ export class Promotion extends Scene {
         let bgX = this.cameras.main.width;
         let bgY = this.cameras.main.height;
         this.add
-            .text(512, 490, "Select what piece to promote your pawn into", {
+            .text(500, 490, "Select what piece to promote your pawn into", {
                 fontFamily: "Arial Black",
                 fontSize: 38,
                 color: "#ffffff",
@@ -41,15 +36,12 @@ export class Promotion extends Scene {
         const rook = this.add.image(bgX/2+150,bgY/2, "rook").setDepth(5).setScale(1.5);
         const pieces = [queen, bishop, knight, rook];
 
-        // Some sort of event listener maybe?
-        // const promotionEvent = new CustomEvent("PawnPromoted", {detail: { rank: this.rank}});
-
         
         queen.setInteractive();
         queen.on(
             "pointerdown",
             function () {
-                // sends event telling promotion happened
+                // sends event telling promotion is to queen
                 EventBus.emit("PawnPromoted", QUEEN);
                 this.scene.stop("Promotion");
                 },
@@ -60,7 +52,7 @@ export class Promotion extends Scene {
         rook.on(
             "pointerdown",
             function () {
-                // sends event telling promotion happened
+                // sends event telling promotion is to rook
                 EventBus.emit("PawnPromoted", ROOK);
                 this.scene.stop("Promotion");
                 },
@@ -71,7 +63,7 @@ export class Promotion extends Scene {
         bishop.on(
             "pointerdown",
             function () {
-                // sends event telling promotion happened
+                // sends event telling promotion is to bishop
                 EventBus.emit("PawnPromoted", BISHOP);
                 this.scene.stop("Promotion");
                 },
@@ -82,44 +74,30 @@ export class Promotion extends Scene {
         knight.on(
             "pointerdown",
             function () {
-                // sends event telling promotion happened
+                // sends event telling promotion is to knight
                 EventBus.emit("PawnPromoted", KNIGHT);
                 this.scene.stop("Promotion");
                 },
                 this
         );
 
-        // Creates a visual background that also blocks input on the scene underneath
+        // make pieces larger when moused over to indicate selection
+        for (let piece in pieces) {
+            // When the pointer hovers over a piece, scale it up
+            pieces[piece].on("pointerover", () => {
+                pieces[piece].setScale(2);
+            });
 
-        const bg = this.add.rectangle(bgX / 2, bgY / 2, bgX, bgY, 0x00ff00, 0.5);
+            // When the pointer moves away from the piece, reset the scale to normal
+            pieces[piece].on("pointerout", () => {
+                pieces[piece].setScale(1.5);
+            });
+        }
+
+        // Creates a visual background that also blocks input on the scene underneath
+        const bg = this.add.rectangle(bgX / 2, bgY / 2, bgX, bgY, 0x3B3B3B, 0.5);
         bg.setOrigin(0.5);
         bg.setInteractive();
-
-
-        const closeButton = this.add.text(100, 100, "Close", {
-            fill: "#0099ff",
-            backgroundColor: "#ffff",
-            padding: { left: 20, right: 20, top: 10, bottom: 10 },
-        });
-        closeButton.setPosition(425, 600);
-        closeButton.setInteractive();
-        closeButton.on(
-            "pointerdown",
-            function () {
-                this.scene.stop("Promotion");
-            },
-            this
-        );
-
-        // When the pointer hovers over the button, scale it up
-        closeButton.on("pointerover", () => {
-            closeButton.setScale(1.2); // Increase the scale (grow the button by 20%)
-        });
-
-        // When the pointer moves away from the button, reset the scale to normal
-        closeButton.on("pointerout", () => {
-            closeButton.setScale(1); // Reset to original size
-        });
 
         EventBus.emit("current-scene-ready", this);
     }

--- a/src/game/scenes/Promotion.js
+++ b/src/game/scenes/Promotion.js
@@ -1,5 +1,9 @@
 import { Scene } from "phaser";
 import { EventBus } from "../EventBus";
+import {QUEEN, BISHOP, ROOK, KNIGHT } from "../../game-objects/constants";
+import {PLAYER, COMPUTER } from "../../game-objects/constants";
+import { Game } from "./Game";
+import { ChessTiles } from "../../game-objects/chess-tiles";
 
 export class Promotion extends Scene {
     constructor() {
@@ -7,17 +11,18 @@ export class Promotion extends Scene {
     }
 
     preload() {
-        this.load.setPath("assets");
-
-        this.load.image("star", "star.png");
-        this.load.image("background", "bg.png");
+        this.load.setPath("assets/drummyfish chess/");
+        this.load.image("queen", "queenB.png");
+        this.load.image("knight", "knightB.png");
+        this.load.image("rook", "rookB.png");
+        this.load.image("bishop", "bishopB.png");
     }
 
     create() {
-        this.add.image(512, 384, "background").alpha = 0.5;
-        this.add.image(512, 350, "star").setDepth(100);
+        let bgX = this.cameras.main.width;
+        let bgY = this.cameras.main.height;
         this.add
-            .text(512, 490, "These are the rules", {
+            .text(512, 490, "Select what piece to promote your pawn into", {
                 fontFamily: "Arial Black",
                 fontSize: 38,
                 color: "#ffffff",
@@ -28,7 +33,36 @@ export class Promotion extends Scene {
             .setOrigin(0.5)
             .setDepth(100);
 
-        const closeButton = this.add.text(100, 100, "Close Rules", {
+        const queen = this.add.image(bgX/2-150,bgY/2, "queen").setDepth(5).setScale(1.5);
+        const bishop = this.add.image(bgX/2-50,bgY/2, "bishop").setDepth(5).setScale(1.5);
+        const knight = this.add.image(bgX/2+50,bgY/2, "knight").setDepth(5).setScale(1.5);
+        const rook = this.add.image(bgX/2+150,bgY/2, "rook").setDepth(5).setScale(1.5);
+        const pieces = [queen, bishop, knight, rook];
+
+        for (let piece in pieces) {
+            console.log("piece:" + piece)
+            pieces[piece].setInteractive();
+            pieces[piece].on(
+                "pointerdown",
+                function () {
+                    // console.log(this.scene.get("MainGame").children);
+                    console.log(ChessTiles);
+                    // ChessTiles.setPromotion(QUEEN,PLAYER);
+                    // this.scene.get("MainGame").scene.setPromotion(QUEEN,PLAYER);
+                    this.scene.stop("Promotion");
+                },
+                this
+            );
+        };
+
+        // Creates a visual background that also blocks input on the scene underneath
+
+        const bg = this.add.rectangle(bgX / 2, bgY / 2, bgX, bgY, 0x00ff00, 0.5);
+        bg.setOrigin(0.5);
+        bg.setInteractive();
+
+
+        const closeButton = this.add.text(100, 100, "Close", {
             fill: "#0099ff",
             backgroundColor: "#ffff",
             padding: { left: 20, right: 20, top: 10, bottom: 10 },
@@ -38,7 +72,7 @@ export class Promotion extends Scene {
         closeButton.on(
             "pointerdown",
             function () {
-                this.scene.stop("Rules");
+                this.scene.stop("Promotion");
             },
             this
         );

--- a/src/game/scenes/Promotion.test.js
+++ b/src/game/scenes/Promotion.test.js
@@ -1,0 +1,120 @@
+import { Promotion } from "./Promotion";
+import { COMPUTER, PAWN, ROOK, QUEEN, PLAYER} from "../../game-objects/constants";
+
+describe("Promotion Scene Display Test", () => {
+    let scene;
+
+    beforeEach(() => {
+        // Setup: Create a new instance of the Start scene for each test
+        scene = new Promotion();
+        
+        // Mock the children array to simulate the scene objects like buttons and text.
+        scene.children = {
+            // Mock the getChildren method, which is responsible for fetching the scene's children objects (e.g., text, buttons)
+            getChildren: jest.fn().mockReturnValue([
+                // Mock the text instructions object with expected properties
+                { text: "Select what piece to promote your pawn into", x: 500, y: 490 },
+                // chess piece buttons
+                {texture: "queen", Depth:5, Scale:1.5, input: { enabled: true }},
+                {texture: "bishop", Depth:5, Scale:1.5, input: { enabled: true }},
+                {texture: "rook", Depth:5, Scale:1.5, input: { enabled: true }},
+                {texture: "knight", Depth:5, Scale:1.5, input: { enabled: true }},
+
+            ]),
+        };
+
+        scene.add = {
+            text: jest.fn().mockReturnValue({
+                // Mock the method chaining typically used when creating Phaser text objects
+                setOrigin: jest.fn(),
+                setDepth: jest.fn(),
+                setInteractive: jest.fn(),
+                on: jest.fn(), // Mock event listener attachment
+            }),
+        };
+    })
+
+    test("text object should be created", () => {
+        // Find the text object with the correct text value from the mocked children array
+        const instructions = scene.children
+            .getChildren()
+            .find((child) => child.text === "Select what piece to promote your pawn into");
+
+        // Assertions to check if the title text is created and its properties are correct
+        expect(instructions).toBeDefined(); // Ensure the title text exists
+        expect(instructions.x).toBe(500); // Ensure its x-position is correct
+        expect(instructions.y).toBe(490); // Ensure its y-position is correct
+    });
+
+    test("chess pieces should be interactive an enabled", () => {
+        // Find the settings button from the mocked children
+        const queenPromotion = scene.children
+            .getChildren()
+            .find((child) => child.texture === "queen");
+
+        // Assertions to check if the settings button exists and is interactive
+        expect(queenPromotion).toBeDefined(); // Ensure the button exists
+        expect(queenPromotion.input.enabled).toBe(true); // Ensure the button is interactive (enabled)
+        expect(queenPromotion.Depth).toBe(5); // depth set correctly
+        expect(queenPromotion.Scale).toBe(1.5); // depth set correctly
+
+
+        const knightPromotion = scene.children
+            .getChildren()
+            .find((child) => child.texture === "knight");
+
+        // Assertions to check if the settings button exists and is interactive
+        expect(knightPromotion).toBeDefined(); // Ensure the button exists
+        expect(knightPromotion.input.enabled).toBe(true); // Ensure the button is interactive (enabled)
+        expect(knightPromotion.Depth).toBe(5); // depth set correctly
+        expect(knightPromotion.Scale).toBe(1.5); // depth set correctly
+
+        const bishopPromotion = scene.children
+            .getChildren()
+            .find((child) => child.texture === "bishop");
+
+        // Assertions to check if the settings button exists and is interactive
+        expect(bishopPromotion).toBeDefined(); // Ensure the button exists
+        expect(bishopPromotion.input.enabled).toBe(true); // Ensure the button is interactive (enabled)
+        expect(bishopPromotion.Depth).toBe(5); // depth set correctly
+        expect(bishopPromotion.Scale).toBe(1.5); // depth set correctly
+
+
+        const rookPromotion = scene.children
+            .getChildren()
+            .find((child) => child.texture === "rook");
+
+        // Assertions to check if the settings button exists and is interactive
+        expect(rookPromotion).toBeDefined(); // Ensure the button exists
+        expect(rookPromotion.input.enabled).toBe(true); // Ensure the button is interactive (enabled)
+        expect(rookPromotion.Depth).toBe(5); // depth set correctly
+        expect(rookPromotion.Scale).toBe(1.5); // depth set correctly
+    });
+});
+
+describe("Promotion logic tests", () => {
+
+    function __mockCheckPromotion([col,row], alignment, rank) {
+        if (rank==PAWN && row==0 && alignment==PLAYER) {
+            return [PLAYER, true];
+        } else if (rank==PAWN && row==7 && alignment==COMPUTER) {
+            return [COMPUTER, true, QUEEN];
+        }
+        return false;
+    }
+
+
+    
+    test("test whether piece is promoted", () => {
+        // Non-royal row, should be false
+        expect(__mockCheckPromotion([5,5],COMPUTER,PAWN)).toBe(false);
+        // own royal row, impossible but should be false
+        expect(__mockCheckPromotion([0,0],COMPUTER,PAWN)).toBe(false);
+        // non-pawn should be false
+        expect(__mockCheckPromotion([7,7],COMPUTER,ROOK)).toBe(false);
+        //black pawn promoted to black queen
+        expect(__mockCheckPromotion([5,7],COMPUTER,PAWN)).toStrictEqual([COMPUTER, true, QUEEN]);  
+        // white pawn should be promoted to something
+        expect(__mockCheckPromotion([5,0],PLAYER,PAWN)).toStrictEqual([PLAYER, true]);        
+    });
+})


### PR DESCRIPTION
Completes issue #19 

- Adds checkPromotion method in ChessTiles which is called after every move to check if the move results in a promotion.
- Automatically promotes the computer piece to a queen. A queen and a knight are the only two possible options and a queen is better 99% of the time. Once we implement the computer's game logic this can be expanded.
- Capture tracking is not implemented on main so this might make it appear the promoted pawn is captured depending on how that implementation interacts with BoardState.destroyPiece.
- If the player pawn is promoted, the game opens the Promotion scene which requires the player to select the piece they want to promote the pawn into by clicking to leave. While open the scene eats game input. Once computer logic is added for it making moves, another lock might need to be added to stop the computer from moving while the player is choosing.
- When the player chooses a piece to promote, an event gives the selection back to ChessTiles, which calls the setPromotion method to change the piece.