### PR TITLE
align chessboard & add non-dynamic sideLights

### DIFF
--- a/src/game-objects/board-state.js
+++ b/src/game-objects/board-state.js
@@ -2,7 +2,7 @@ import { TILE_SIZE, X_ANCHOR, Y_ANCHOR } from './constants';
 import { PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING } from './constants';
 import { PLAYER, COMPUTER } from './constants';
 import { EN_PASSANT_TOKEN } from './constants';
-import { isSamePoint } from "./constants";
+import { isSamePoint, dim2Array } from "./constants";
 import { ChessPiece } from './chess-piece';
 
 export class BoardState {
@@ -13,11 +13,10 @@ export class BoardState {
     constructor(scene) {
         this.#scene = scene;
 
-        this.#boardState = []; // 8x8 array of chess pieces
+        this.#boardState = dim2Array(8, 8); // 8x8 array of chess pieces
 
         // set up boardState & initialize player pieces (and computer pieces for testing purposes)
         for (let i = 0; i < 8; i++) {
-            this.#boardState.push([]);
             // Initialize Player (white) pieces
             for (let j = 6; j < 8; j++)
                 if (j == 6)

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -2,7 +2,7 @@ import { TILE_SIZE, X_ANCHOR, Y_ANCHOR } from "./constants";
 import { HOVER_COLOR, WHITE_TILE_COLOR, BLACK_TILE_COLOR, NON_LETHAL_COLOR, LETHAL_COLOR, THREAT_COLOR, STAGE_COLOR } from "./constants";
 import { PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING } from "./constants";
 import { PLAYER, COMPUTER } from "./constants";
-import { isSamePoint } from "./constants";
+import { isSamePoint, dim2Array } from "./constants";
 import { DEV_MODE } from "./constants";
 import { BoardState } from "./board-state";
 import { EventBus } from "../game/EventBus";
@@ -13,7 +13,7 @@ export class ChessTiles {
     constructor(scene) {
         this.scene = scene;
         this.piecesTaken;
-        this.chessTiles = [];   // 8x8 array of chess tiles
+        this.chessTiles;        // 8x8 array of chess tiles
         this.boardState;        // contains BoardState object that manages an 8x8 array of chess pieces
         this.xy;                // coordinate of selected chess piece; list of [i,j]
         this.moves;             // possible moves of selected chess piece; list of dictionaries of {'xy':[#,#],'isEnemy':boolean}
@@ -21,6 +21,7 @@ export class ChessTiles {
         this.threats;           // temporary storage of threats to chess piece, list of lists of [#,#]
         this.promotionCol;      // temporary storage of column of piece to promote
         this.promotionRow;      // temporary storage of row of piece to promote
+        this.sideLights;        // numbers & letters on edge of chessboard that highlight in response to cursor
         this.currentPlayer = PLAYER;
 
         // Set up stage behind (surrounding) chessboard
@@ -32,9 +33,27 @@ export class ChessTiles {
             STAGE_COLOR
         );
 
+        this.sideLights = dim2Array(4, 8);
+        for (let i = 0; i < 4; i++)
+            for (let j = 0; j < 8; j++)
+                switch (i) {
+                    case 0: // [0,1][0~7] top & bottom rows of a~h
+                        this.sideLights[i][j] = this.scene.add.text(X_ANCHOR + j * TILE_SIZE, Y_ANCHOR - 0.75 * TILE_SIZE, String.fromCharCode(65 + j), {fontSize: TILE_SIZE/2}).setOrigin(0.5);
+                        break;
+                    case 1: // [0,1][0~7] top & bottom rows of a~h
+                        this.sideLights[i][j] = this.scene.add.text(X_ANCHOR + j * TILE_SIZE, Y_ANCHOR + 7.75 * TILE_SIZE, String.fromCharCode(65 + j), {fontSize: TILE_SIZE/2}).setOrigin(0.5);
+                        break;
+                    case 2: // [2,3][0~7] left & right columns of 1~8
+                        this.sideLights[i][j] = this.scene.add.text(X_ANCHOR - 0.75 * TILE_SIZE, Y_ANCHOR + j * TILE_SIZE, 8 - j, {fontSize: TILE_SIZE/2}).setOrigin(0.5);
+                        break;
+                    case 3: // [2,3][0~7] left & right columns of 1~8
+                        this.sideLights[i][j] = this.scene.add.text(X_ANCHOR + 7.75 * TILE_SIZE, Y_ANCHOR + j * TILE_SIZE, 8 - j, {fontSize: TILE_SIZE/2}).setOrigin(0.5);
+                        break;
+                }
+
         // Set up chessTiles & pointer behaviour, as well as interaction with pieces
+        this.chessTiles = dim2Array(8, 8);
         for (let i = 0; i < 8; i++) {
-            this.chessTiles.push([]);
             for (let j = 0; j < 8; j++) {
                 // Initialize tiles & enable interaction
                 this.chessTiles[i][j] = this.scene.add.rectangle(
@@ -202,7 +221,7 @@ export class ChessTiles {
     toggleTurn() {
         this.currentPlayer = (this.currentPlayer === PLAYER) ? COMPUTER : PLAYER;
     }
-
+    
     // ================================================================
     // Tile Highlight & Restoration
 

--- a/src/game-objects/constants.js
+++ b/src/game-objects/constants.js
@@ -1,6 +1,6 @@
 const TILE_SIZE = 80;                       // width & height of each tile
-const X_ANCHOR = 512 - 3.5 * TILE_SIZE;     // x pixel of leftmost tile
-const Y_ANCHOR = 384 - 3.5 * TILE_SIZE;     // y pixel of topmost tile
+const X_ANCHOR = 500 - 3.5 * TILE_SIZE;     // x pixel of leftmost tile
+const Y_ANCHOR = 360 - 3.5 * TILE_SIZE;     // y pixel of topmost tile
 
 const GRAY = "7D7F7C";
 const FAWN = "E5AA70";
@@ -12,6 +12,7 @@ const DARK_GREY = "3B3B3B";
 const ONYX = "3B3B3B";
 const CREAM = "F4FFFD";
 const GREEN = "6E9075";
+const DARK_BROWN = "5C4033";
 
 const ZEROX = "0x";
 const HASH = "#";
@@ -22,7 +23,7 @@ const BLACK_TILE_COLOR = ZEROX + MAHOGANY;  // black tile color
 const NON_LETHAL_COLOR = ZEROX + VIOLET;    // non-lethal move color
 const LETHAL_COLOR = ZEROX + MAGNETA;       // lethal move color
 const THREAT_COLOR = ZEROX + AZURE;         // threat color
-const STAGE_COLOR = ZEROX + DARK_GREY;      // chessboard stage color
+const STAGE_COLOR = ZEROX + DARK_BROWN;     // chessboard stage color
 
 const BACKGROUND_COLOR = ZEROX + ONYX;
 
@@ -54,12 +55,16 @@ export function isSamePoint([col1, row1], [col2, row2]) {
     return col1 == col2 && row1 == row2;
 }
 
+export function dim2Array(dim1, dim2) {
+    return Array.from(Array(dim1), () => new Array(dim2));
+}
+
 export { TILE_SIZE, X_ANCHOR, Y_ANCHOR };
 
 export { HOVER_COLOR, WHITE_TILE_COLOR, BLACK_TILE_COLOR, NON_LETHAL_COLOR, LETHAL_COLOR, THREAT_COLOR, STAGE_COLOR };
 export { BACKGROUND_COLOR };
 export { ONYXHEX, CREAMHEX, FAWNHEX, MAHOGANYHEX, GREENHEX }
-export {START_BACKGROUND_COLOR, START_TEXT_ONE, START_TEXT_TWO};
+export { START_BACKGROUND_COLOR, START_TEXT_ONE, START_TEXT_TWO };
 
 export { PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING };
 export { PLAYER, COMPUTER };

--- a/src/game-objects/test/chessboard.test.js
+++ b/src/game-objects/test/chessboard.test.js
@@ -67,10 +67,13 @@ describe("", () => {
     class MockScene {
         constructor() {}
 
-        // Mock the add.rectangle & add.existing methods
+        // Mock the add.rectangle & add.text & add.existing methods
         add = {
             rectangle: jest.fn((x, y, width, height, color) => {
                 return new MockRectangle(x, y, width, height, color);
+            }),
+            text: jest.fn((x, y, text, style) => {
+                return new MockText(x, y, text, style);
             }),
             existing: jest.fn(),
         }
@@ -91,6 +94,28 @@ describe("", () => {
 
         setFillStyle(color) {
             this.fillColor = color;
+        }
+    }
+
+    // Mock Text class
+    class MockText {
+        constructor(x, y, text, style) {
+            this.x = x;
+            this.y = y;
+            this.text = text;
+            this.style = style;
+            this.origin = 0;
+        }
+
+        setInteractive() { }
+        on() { }
+
+        setFillStyle(color) {
+            this.fillColor = color;
+        }
+
+        setOrigin(origin) {
+            this.origin = origin;
         }
     }
 


### PR DESCRIPTION
1. The chessboard dimensions are slightly altered & is recentered in light of the disappearance of the background and other objects (pieces taken) to align to.
2. An incomplete implementation of sideLights is added. The images are added to the array but they are not yet set to light up in response to which tile the cursor is hovering over.
3. Changed chessboard edge color to a more hearty brown.
4. Add mocking for scene.add.text & text.setOrigin