### PR TITLE
add king royal & coordinate tracking & fix indent

### DIFF
--- a/src/game-objects/chess-piece.js
+++ b/src/game-objects/chess-piece.js
@@ -2,12 +2,14 @@ export class ChessPiece extends Phaser.GameObjects.Image {
     #rank;
     #alignment;
     #moveCounter;
+    #coordinate;
 
-    constructor(scene, x, y, rank, alignment) {
+    constructor(scene, x, y, rank, alignment, coordinate) {
         super(scene, x, y, rank + alignment);
         this.#rank = rank;
         this.#alignment = alignment;
         this.#moveCounter = 0;
+        this.#coordinate = coordinate;
     }
 
     getRank() {
@@ -24,5 +26,13 @@ export class ChessPiece extends Phaser.GameObjects.Image {
 
     incrementMoveCounter() {
         this.#moveCounter++;
+    }
+
+    setCoordinate(col, row) {
+        this.#coordinate = [col, row];
+    }
+
+    getCoordinate(col, row) {
+        return this.#coordinate;
     }
 }  

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -1,28 +1,35 @@
 import { TILE_SIZE, X_ANCHOR, Y_ANCHOR } from "./constants";
-import { HOVER_COLOR, WHITE_TILE_COLOR, BLACK_TILE_COLOR, NON_LETHAL_COLOR, LETHAL_COLOR, THREAT_COLOR, STAGE_COLOR } from "./constants";
+import { HOVER_COLOR, WHITE_TILE_COLOR, BLACK_TILE_COLOR, NON_LETHAL_COLOR, LETHAL_COLOR, THREAT_COLOR, CHECKED_COLOR, STAGE_COLOR } from "./constants";
 import { PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING } from "./constants";
 import { PLAYER, COMPUTER } from "./constants";
 import { isSamePoint, dim2Array } from "./constants";
 import { DEV_MODE } from "./constants";
 import { BoardState } from "./board-state";
 import { EventBus } from "../game/EventBus";
+import { PieceCoordinates } from './piece-coordinates';
 import { PiecesTaken } from "./pieces-taken";
 
 export class ChessTiles {
 
     constructor(scene) {
         this.scene = scene;
-        this.piecesTaken;
         this.chessTiles;        // 8x8 array of chess tiles
         this.boardState;        // contains BoardState object that manages an 8x8 array of chess pieces
+        this.pieceCoordinates;  // contains PieceCoordinates object that manages coordinate info sorted by rank & alignment
+        this.piecesTaken;       // contains PiecesTaken object that logs captured pieces
+
         this.xy;                // coordinate of selected chess piece; list of [i,j]
         this.moves;             // possible moves of selected chess piece; list of dictionaries of {'xy':[#,#],'isEnemy':boolean}
         this.temp;              // temporary storage of coordinate & color; list of dictionaries of {'xy':[#,#],'color':color}
         this.threats;           // temporary storage of threats to chess piece, list of lists of [#,#]
+
         this.promotionCol;      // temporary storage of column of piece to promote
         this.promotionRow;      // temporary storage of row of piece to promote
+
         this.sideLights;        // numbers & letters on edge of chessboard that highlight in response to cursor
-        this.currentPlayer = PLAYER;
+
+        this.currentPlayer = PLAYER;    // denotes current player
+        this.isChecked;         // is true if the current player's king is checked
 
         // Set up stage behind (surrounding) chessboard
         this.scene.add.rectangle(
@@ -82,7 +89,8 @@ export class ChessTiles {
             }
         }
 
-        this.boardState = new BoardState(this.scene);
+        this.pieceCoordinates = new PieceCoordinates();
+        this.boardState = new BoardState(this.scene, this.pieceCoordinates);
         this.piecesTaken = new PiecesTaken(this.scene);
     }
 
@@ -93,7 +101,7 @@ export class ChessTiles {
     pointerOver(i, j) {
         // if highlighted as possible move, save state to restore on pointerout
         let color = this.chessTiles[i][j].fillColor;
-        if (color == NON_LETHAL_COLOR || color == LETHAL_COLOR)
+        if ([NON_LETHAL_COLOR, LETHAL_COLOR, CHECKED_COLOR].includes(color))
             this.temp = [{ xy: [i, j], color: color }];
 
         // highlight tile
@@ -107,7 +115,7 @@ export class ChessTiles {
             for (let tile of this.threats)
                 if (!this.xy || !isSamePoint(this.xy, tile)) {
                     color = this.chessTiles[tile[0]][tile[1]].fillColor;
-                    if (color == NON_LETHAL_COLOR || color == LETHAL_COLOR)
+                    if ([NON_LETHAL_COLOR, LETHAL_COLOR, CHECKED_COLOR].includes(color))
                         this.temp.push({ xy: tile, color: color });
                     this.highlightColor(tile, THREAT_COLOR);
                 }
@@ -120,11 +128,6 @@ export class ChessTiles {
         if (!this.xy || !isSamePoint(this.xy, [i, j]))
             this.restoreColor([i, j]);
 
-        // restore highlighted lethal / non-lethal tile colors, if selected piece exists
-        if (this.temp)
-            for (let tile of this.temp)
-                this.highlightColor(tile.xy, tile.color);
-
         // restore highlighted this.threats to board color, unless is HOVER or LETHAL color
         if (this.threats)
             for (let tile of this.threats) {
@@ -132,6 +135,11 @@ export class ChessTiles {
                 if (color != HOVER_COLOR && color != LETHAL_COLOR)
                     this.restoreColor(tile);
             }
+
+        // restore highlighted lethal / non-lethal tile colors, if selected piece exists
+        if (this.temp)
+            for (let tile of this.temp)
+                this.highlightColor(tile.xy, tile.color);
 
         this.temp = null;
         this.threats = null;
@@ -141,9 +149,6 @@ export class ChessTiles {
     pointerSelect(i, j) {
         let pointerOver = true;
     
-        // Check whose turn it is
-        const currentPlayer = this.currentPlayer;
-    
         // If the tile is the same as the selected, unselect the piece
         if (this.xy && isSamePoint(this.xy, [i, j])) {
             this.clearBoard();
@@ -151,9 +156,9 @@ export class ChessTiles {
         // If the tile is occupied, check if the selected piece is the player's piece
         else if (this.boardState.isOccupied(i, j)) {
             switch (this.boardState.getAlignment(i, j)) {
-                case currentPlayer: // If it's the current player's piece
+                case this.currentPlayer: // If it's the current player's piece
                     this.clearBoard();
-    
+
                     // Highlight tile and possible moves, and record the selected piece in xy
                     this.highlightColor([i, j], HOVER_COLOR);
                     this.moves = this.boardState.searchMoves(i, j);
@@ -165,14 +170,14 @@ export class ChessTiles {
                     this.xy = [i, j];
                     pointerOver = false;
                     break;
-                case (currentPlayer === PLAYER ? COMPUTER : PLAYER): // If it's the opponent's piece
+                case (this.currentPlayer === PLAYER ? COMPUTER : PLAYER): // If it's the opponent's piece
                     // If previously selected piece exists and move is valid, destroy and move the piece
                     if (this.xy && this.isValidMove([i, j])) {
                         this.capturePiece(this.boardState.getRank(i, j), this.boardState.getAlignment(i, j));
                         this.boardState.destroyPiece(i, j);
                         this.boardState.movePiece(this.xy, [i, j]);
                         // check to see if move results in pawn promotion
-                        this.checkPromotion([i, j])
+                        this.checkPromotion([i, j]);
                         this.clearBoard();
                         // Toggle turn after the move
                         this.toggleTurn();
@@ -185,7 +190,7 @@ export class ChessTiles {
             // if en passant move, destroy enemy pawn
             if (this.boardState.getRank(this.xy[0], this.xy[1]) == PAWN &&
                 this.boardState.isEnPassant(i, j)
-            ){
+            ) {
                 this.capturePiece(this.boardState.getRank(i, this.xy[1]), this.boardState.getAlignment(i, this.xy[1]));
                 this.boardState.destroyPiece(i, this.xy[1]);
             }
@@ -198,7 +203,7 @@ export class ChessTiles {
             // move piece & clear board
             this.boardState.movePiece(this.xy, [i, j]);
             // check to see if move results in pawn promotion
-            this.checkPromotion([i, j])
+            this.checkPromotion([i, j]);
             this.clearBoard();
     
             // Toggle turn after the move
@@ -211,15 +216,25 @@ export class ChessTiles {
         this.temp = null;
     
         // If something happened resulting in un-selection, trigger pointerout & pointerover event
-        if (pointerOver)
-        {
+        if (pointerOver) {
             this.pointerOut(i, j);
             this.pointerOver(i, j);
+            // highlight checked king if checked
+            if (this.isChecked)
+            {
+                let coordinate = this.pieceCoordinates.getCoordinate(KING, this.currentPlayer);
+                this.temp.push({ xy: coordinate, color: CHECKED_COLOR });
+            }
         }
     }
     
     toggleTurn() {
         this.currentPlayer = (this.currentPlayer === PLAYER) ? COMPUTER : PLAYER;
+        this.isChecked = this.boardState.isChecked(this.currentPlayer);
+        if (this.isChecked) {
+            let coordinate = this.pieceCoordinates.getCoordinate(KING, this.currentPlayer);
+            this.highlightColor(coordinate, CHECKED_COLOR);
+        }
     }
     
     // ================================================================
@@ -259,12 +274,12 @@ export class ChessTiles {
         if (!this.moves)
             return false;
         for (let move of this.moves)
-            if (move.xy[0] == col && move.xy[1] == row)
+            if (isSamePoint(move.xy, [col, row]))
                 return true;
         return false;
     }
 
-    //add captured piece to the captured pieces
+    // add captured piece to the captured pieces
     capturePiece(rank, alignment) {
         this.piecesTaken.takePiece(rank, alignment);
     }

--- a/src/game-objects/constants.js
+++ b/src/game-objects/constants.js
@@ -13,6 +13,7 @@ const ONYX = "3B3B3B";
 const CREAM = "F4FFFD";
 const GREEN = "6E9075";
 const DARK_BROWN = "5C4033";
+const BLACK = "000000";
 
 const ZEROX = "0x";
 const HASH = "#";
@@ -23,6 +24,7 @@ const BLACK_TILE_COLOR = ZEROX + MAHOGANY;  // black tile color
 const NON_LETHAL_COLOR = ZEROX + VIOLET;    // non-lethal move color
 const LETHAL_COLOR = ZEROX + MAGNETA;       // lethal move color
 const THREAT_COLOR = ZEROX + AZURE;         // threat color
+const CHECKED_COLOR = ZEROX + BLACK;        // checked color
 const STAGE_COLOR = ZEROX + DARK_BROWN;     // chessboard stage color
 
 const BACKGROUND_COLOR = ZEROX + ONYX;
@@ -34,7 +36,7 @@ const START_TEXT_TWO = HASH + MAHOGANY;     // secondary text color / outline co
 const FAWNHEX = "E5AA70";
 const MAHOGANYHEX = "C04000";
 const ONYXHEX = HASH + "3B3B3B";
-const CREAMHEX = HASH+ "F4FFFD";
+const CREAMHEX = HASH + "F4FFFD";
 const GREENHEX = "6E9075";
 
 const PAWN = "pawn";                        // pawn rank
@@ -61,7 +63,7 @@ export function dim2Array(dim1, dim2) {
 
 export { TILE_SIZE, X_ANCHOR, Y_ANCHOR };
 
-export { HOVER_COLOR, WHITE_TILE_COLOR, BLACK_TILE_COLOR, NON_LETHAL_COLOR, LETHAL_COLOR, THREAT_COLOR, STAGE_COLOR };
+export { HOVER_COLOR, WHITE_TILE_COLOR, BLACK_TILE_COLOR, NON_LETHAL_COLOR, LETHAL_COLOR, THREAT_COLOR, CHECKED_COLOR, STAGE_COLOR };
 export { BACKGROUND_COLOR };
 export { ONYXHEX, CREAMHEX, FAWNHEX, MAHOGANYHEX, GREENHEX }
 export { START_BACKGROUND_COLOR, START_TEXT_ONE, START_TEXT_TWO };

--- a/src/game-objects/piece-coordinates.js
+++ b/src/game-objects/piece-coordinates.js
@@ -1,0 +1,60 @@
+import { PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING } from './constants';
+import { PLAYER, COMPUTER } from './constants';
+
+export class PieceCoordinates {
+    #coordinates
+
+    constructor() {
+        this.#coordinates = {};
+        for (let alignment of [PLAYER, COMPUTER]) {
+            this.#coordinates[alignment] = {};
+            for (let rank of [PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING])
+                this.#coordinates[alignment][rank] = [];
+        }
+    }
+
+    addCoordinate(col, row, rank, alignment) {
+        this.#coordinates[alignment][rank].push([col, row]);
+    }
+
+    moveCoordinate(input, output, rank, alignment) {
+        let incol = input[0];
+        let inrow = input[1];
+        let outcol = output[0];
+        let outrow = output[1];
+        
+        let index = this.findIndex(incol, inrow, rank, alignment);
+        if(index == null)
+            return false;
+        this.#coordinates[alignment][rank][index] = [outcol, outrow];
+        return true;
+    }
+
+    getCoordinate(rank, alignment) {
+        return this.#coordinates[alignment][rank][0];
+    }
+
+    getAllCoordinates(alignment) {
+        let coordinates = [];
+        for (let rank of [PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING])
+            for (let piece of this.#coordinates[alignment][rank])
+                coordinates.push(piece);
+        return coordinates;
+    }
+
+    deleteCoordinate(col, row, rank, alignment) {
+        let index = this.findIndex(col, row, rank, alignment);
+        if(index == null)
+            return false;
+        this.#coordinates[alignment][rank].splice(index, index);
+        return true;
+    }
+
+    findIndex(col, row, rank, alignment) {
+        let index = 0;
+        for (; index < this.#coordinates[alignment][rank].length; index++)
+            if (col == this.#coordinates[alignment][rank][index][0] && row == this.#coordinates[alignment][rank][index][1])
+                return index;
+        return null;
+    }
+}  

--- a/src/game-objects/pieces-taken.js
+++ b/src/game-objects/pieces-taken.js
@@ -9,7 +9,7 @@ import { PLAYER, COMPUTER } from './constants';
 import { ChessPiece } from './chess-piece';
 
 
-export class PiecesTaken{
+export class PiecesTaken {
 
     scene;
     piecesTaken;
@@ -24,7 +24,7 @@ export class PiecesTaken{
     nextPawnW;
     nextPawnB;
 
-    constructor (scene){
+    constructor (scene) {
 
         //set up variables to keep track of elements
         this.scene = scene;
@@ -218,7 +218,7 @@ export class PiecesTaken{
     }
 
     //updates x and y to keep track of where to put the next captured piece
-    updateXY(){
+    updateXY() {
         if (this.y == 7){
             this.x += 1;
             this.y = 0;

--- a/src/game-objects/test/chessboard.test.js
+++ b/src/game-objects/test/chessboard.test.js
@@ -5,7 +5,6 @@ jest
   .mockImplementation(([col, row]) => {
     return false;
   });
-import { ChessPiece } from "../chess-piece.js";
 // Mock ChessPiece class
 class MockChessPiece {
     constructor(scene, x, y, rank, alignment) {
@@ -15,6 +14,7 @@ class MockChessPiece {
         this.rank = rank;
         this.alignment = alignment;
         this.moveCounter = 0;
+        this.coordinate = null;
 
         this.image = rank + alignment;
     }
@@ -40,6 +40,14 @@ class MockChessPiece {
         this.moveCounter++;
     }
 
+    setCoordinate(col, row) {
+        this.coordinate = [col, row];
+    }
+
+    getCoordinate() {
+        return this.coordinate;
+    }
+
     destroy() { }
 }
 jest.mock("../chess-piece", () => {
@@ -51,7 +59,7 @@ jest.mock("../chess-piece", () => {
 import { POINTER_OVER, POINTER_OUT, POINTER_DOWN, WHEEL } from "./test-constants.js";
 import { LEFT, RIGHT, UP, DOWN } from "./test-constants.js";
 
-import { HOVER_COLOR, WHITE_TILE_COLOR, BLACK_TILE_COLOR, NON_LETHAL_COLOR, LETHAL_COLOR, THREAT_COLOR, STAGE_COLOR } from "../constants.js";
+import { HOVER_COLOR, WHITE_TILE_COLOR, BLACK_TILE_COLOR, NON_LETHAL_COLOR, LETHAL_COLOR, THREAT_COLOR, CHECKED_COLOR, STAGE_COLOR } from "../constants.js";
 import { PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING } from "../constants.js";
 import { PLAYER, COMPUTER } from "../constants.js";
 
@@ -192,31 +200,9 @@ describe("", () => {
         mockTileEvent("pointerover");
     });
 
-    /*
-
-    TODO LIST
-
-    ::: MACRO :::
-    X. Do all of the following for when a piece is selected & not
-    1. Move pointer & check if colors highlight & un-highlight properly
-    2. Click tile where non-response is expected & check if nothing happened (as intended)
-    3. Click tile where response is expected & check if said response happened (as intended)
-        a. selection
-        b. re-selection
-        c. un-selection
-        d. non-lethal move
-        e. lethal move
-
-    ::: MICRO :::
-    1. Check Pointer Events methods
-    2. Check Tile Highlight & Restoration methods
-    3. Check Miscellaneous methods
-
-    */
 
 
-
-    // Test Template
+    // Tests
     test("Test Functions Functionality", () => {
         expect(scene).toBeDefined();
         expect(tiles).toBeDefined();
@@ -327,7 +313,7 @@ describe("", () => {
         click(4, 7);
         expect(tiles.chessTiles[2][7].fillColor).toBe(tiles.getTileColor([4, 7]));
         expect(tiles.chessTiles[6][7].fillColor).toBe(tiles.getTileColor([2, 7]));
-    })
+    });
 
     test("Threat Detection", () => {
         tiles.boardState.addPiece(6, 5, KING, COMPUTER);
@@ -358,6 +344,45 @@ describe("", () => {
         tiles.boardState.addPiece(2, 3, KING, COMPUTER);
         shift(3, 3);
         expect(tiles.chessTiles[2][3].fillColor).toBe(THREAT_COLOR);
-    })
+    });
+
+    test("King is Royal", () => {
+        click(4, 6);
+        click(4, 4);
+        click(4, 1);
+        click(4, 3);
+        click(5, 6);
+        click(5, 4);
+        click(5, 1);
+        click(5, 3);
+        click(3, 7);
+        click(7, 3);
+        expect(tiles.chessTiles[4][0].fillColor).toBe(CHECKED_COLOR);
+        click(4, 0);
+        expect(tiles.chessTiles[4][0].fillColor).toBe(HOVER_COLOR);
+        expect(tiles.chessTiles[5][1].fillColor).toBe(tiles.getTileColor([5, 1]));
+        expect(tiles.chessTiles[4][1].fillColor).toBe(NON_LETHAL_COLOR);
+        click(4, 1);
+        shift(0, 0);
+        expect(tiles.chessTiles[4][0].fillColor).toBe(tiles.getTileColor([4, 0]));
+        expect(tiles.chessTiles[4][1].fillColor).toBe(tiles.getTileColor([4, 1]));
+        click(7, 3);
+        click(5, 1);
+        expect(tiles.chessTiles[4][1].fillColor).toBe(THREAT_COLOR);
+        shift(0, 0);
+        expect(tiles.chessTiles[4][1].fillColor).toBe(CHECKED_COLOR);
+        click(4, 1);
+        shift(0, 0);
+        expect(tiles.chessTiles[4][0].fillColor).toBe(tiles.getTileColor([4, 0]));
+        expect(tiles.chessTiles[5][1].fillColor).toBe(LETHAL_COLOR);
+        expect(tiles.chessTiles[5][2].fillColor).toBe(tiles.getTileColor([5, 2]));
+        expect(tiles.chessTiles[4][2].fillColor).toBe(tiles.getTileColor([4, 2]));
+        expect(tiles.chessTiles[3][2].fillColor).toBe(NON_LETHAL_COLOR);
+    });
+
+    test("Miscellaneous", () => {
+        expect(tiles.pieceCoordinates.moveCoordinate([4, 4], [4, 4], PAWN, PLAYER)).toBe(false);
+        expect(tiles.pieceCoordinates.deleteCoordinate(4, 4, PAWN, PLAYER)).toBe(false);
+    });
 });
 

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -2,10 +2,9 @@ import { Scene } from "phaser";
 import { EventBus } from "../EventBus";
 
 import { SettingsButton } from "./SettingsButton";
-
 import { RulesButton } from "./RulesButton";
-import { ChessTiles } from '../../game-objects/chess-tiles';
 
+import { ChessTiles } from '../../game-objects/chess-tiles';
 
 import { PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING } from "../../game-objects/constants";
 import { CREAMHEX, ONYXHEX } from "../../game-objects/constants";
@@ -15,6 +14,7 @@ export class Game extends Scene {
     constructor() {
         super("MainGame");
     }
+
     preload() {
         this.load.setPath("assets");
         // Load Chess piece pngs
@@ -27,23 +27,11 @@ export class Game extends Scene {
     create() {
 
         this.add.image(512, 384, "background");
-        //         this.add.image(512, 350, "star").setDepth(100);
-        //         this.add
-        //             .text(512, 490, "You are currently playing the game", {
-        //                 fontFamily: "Arial Black",
-        //                 fontSize: 38,
-        //                 color: "#ffffff",
-        //                 stroke: "#000000",
-        //                 strokeThickness: 8,
-        //                 align: "center",
-        //             })
-        //             .setOrigin(0.5)
-        //             .setDepth(100);
 
 
 
         // and a board, and an icon, and a black tile, and a white tile; Totaling to 40 images
-new ChessTiles(this);
+        new ChessTiles(this);
 
         const endButton = this.add.text(100, 100, "End Game!", {
             fill: CREAMHEX,
@@ -54,21 +42,16 @@ new ChessTiles(this);
         endButton.setInteractive();
         endButton.setOrigin(0.5);
 
-        // endButton.on("pointerdown", () => {
-        //     this.scene.start("GameOver"); // Reset to original size
-        // });
-
         endButton.on(
             "pointerdown",
             function () {
-                
                 import("./GameOver") // 
                     .then((module) => {
                         // Only add the scene if it's not already registered
                         if (!this.scene.get("GameOver")) {
                             this.scene.add("GameOver", module.GameOver); // Add the MainGame scene dynamically
                         }
- // Start the MainGame scene
+                        // Start the MainGame scene
                         this.scene.start("GameOver");
                     });
             },
@@ -121,7 +104,7 @@ new ChessTiles(this);
         rulesButton.setPosition(1050, 650);
 
         rulesButton.setInteractive();
-   rulesButton.setOrigin(0.5);
+        rulesButton.setOrigin(0.5);
         rulesButton.on("pointerdown", new RulesButton(this).click, this);
 
         // When the pointer hovers over the button, scale it up

--- a/src/game/scenes/Promotion.js
+++ b/src/game/scenes/Promotion.js
@@ -1,6 +1,6 @@
 import { Scene } from "phaser";
 import { EventBus } from "../EventBus";
-import {QUEEN, BISHOP, ROOK, KNIGHT, X_ANCHOR, Y_ANCHOR, TILE_SIZE } from "../../game-objects/constants";
+import { QUEEN, BISHOP, ROOK, KNIGHT, X_ANCHOR, Y_ANCHOR, TILE_SIZE } from "../../game-objects/constants";
 
 export class Promotion extends Scene {
     constructor() {
@@ -44,9 +44,9 @@ export class Promotion extends Scene {
                 // sends event telling promotion is to queen
                 EventBus.emit("PawnPromoted", QUEEN);
                 this.scene.stop("Promotion");
-                },
-                this
-            );
+            },
+            this
+        );
         
         rook.setInteractive();
         rook.on(
@@ -55,8 +55,8 @@ export class Promotion extends Scene {
                 // sends event telling promotion is to rook
                 EventBus.emit("PawnPromoted", ROOK);
                 this.scene.stop("Promotion");
-                },
-                this
+            },
+            this
         );
 
         bishop.setInteractive();
@@ -66,8 +66,8 @@ export class Promotion extends Scene {
                 // sends event telling promotion is to bishop
                 EventBus.emit("PawnPromoted", BISHOP);
                 this.scene.stop("Promotion");
-                },
-                this
+            },
+            this
         );
 
         knight.setInteractive();
@@ -77,8 +77,8 @@ export class Promotion extends Scene {
                 // sends event telling promotion is to knight
                 EventBus.emit("PawnPromoted", KNIGHT);
                 this.scene.stop("Promotion");
-                },
-                this
+            },
+            this
         );
 
         // make pieces larger when moused over to indicate selection


### PR DESCRIPTION
1. Implement check. Specifically highlighting the king when checked, and disallowing any move other than what would get the king out of check.
2. Add coordinate tracking via dictionary so that there is no need to scour all 64 tiles every time search for a specific piece at an unknown location.
3. Add placeholder checkmate & stalemate methods that will be finessed out in the next PBI.
4. Implement testing for the 'check' mechanism.
5. Fix some miscellaneous indentation issues and removed now-redundant commented out code.

Resolves #25 