### PR TITLE
fix ally piece putting king into check

### DIFF
--- a/src/game-objects/board-state.js
+++ b/src/game-objects/board-state.js
@@ -503,8 +503,6 @@ export class BoardState {
 
     // Check whether king would be saved/un-threatened if move is made
     kingSaved(input, output, alignment) {
-        if (!this.#isChecked)
-            return true;
         let coordinate = this.#pieceCoordinates.getCoordinate(KING, alignment);
         let col = isSamePoint(input, coordinate) ? output[0] : coordinate[0];
         let row = isSamePoint(input, coordinate) ? output[1] : coordinate[1];


### PR DESCRIPTION
Fix small issue of an ally piece (while king is not in check) being able to make a move that would put the king in check