### PR TITLE
fix piece-coordinates splice & spawnNextWave typo

### DIFF
--- a/src/game-objects/board-state.js
+++ b/src/game-objects/board-state.js
@@ -530,18 +530,15 @@ export class BoardState {
     // Check whether king would be saved/un-threatened if move is made
     kingSaved(input, output, alignment) {
         let coordinate = this.#pieceCoordinates.getCoordinate(KING, alignment);
-        let col = isSamePoint(input, coordinate) ? output[0] : coordinate[0];
-        let row = isSamePoint(input, coordinate) ? output[1] : coordinate[1];
-        return !this.seekThreats(col, row, alignment, input, output).length;
+        coordinate = isSamePoint(input, coordinate) ? output : coordinate;
+        return !this.seekThreats(...coordinate, alignment, input, output).length;
     }
 
     // Check whether king of alignment is threatened
     isChecked(alignment) {
         let coordinate = this.#pieceCoordinates.getCoordinate(KING, alignment);
-        let col = coordinate[0];
-        let row = coordinate[1];
 
-        this.#isChecked = !!this.seekThreats(col, row, alignment).length;
+        this.#isChecked = !!this.seekThreats(...coordinate, alignment).length;
         return this.#isChecked;
     }
 

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -294,7 +294,7 @@ export class ChessTiles {
     
     // Toggle turn & check board state & spawn wave counter
     toggleTurn(override=false) {
-        // if Flip! is clicked (override) or Stop! is enabled
+        // if Flip! is clicked (override) or Stop! is disabled
         if (override || !dev_stopOn) {
             if (this.currentPlayer == PLAYER) {
                 // If we're about to switch to the computer, check if any piece has valid moves
@@ -398,7 +398,7 @@ export class ChessTiles {
                         }
 
                         // Prevent an infinite impossible loop if the entire board is full
-                        if (testSpawnIndex >= testSpawnLocations.Length)
+                        if (testSpawnIndex >= testSpawnLocations.length)
                             outOfSpawns = true;
                     }
                 }

--- a/src/game-objects/piece-coordinates.js
+++ b/src/game-objects/piece-coordinates.js
@@ -18,15 +18,10 @@ export class PieceCoordinates {
     }
 
     moveCoordinate(input, output, rank, alignment) {
-        let incol = input[0];
-        let inrow = input[1];
-        let outcol = output[0];
-        let outrow = output[1];
-        
-        let index = this.findIndex(incol, inrow, rank, alignment);
+        let index = this.findIndex(...input, rank, alignment);
         if (index == null)
             return false;
-        this.#coordinates[alignment][rank][index] = [outcol, outrow];
+        this.#coordinates[alignment][rank][index] = output;
         return true;
     }
 

--- a/src/game-objects/piece-coordinates.js
+++ b/src/game-objects/piece-coordinates.js
@@ -24,7 +24,7 @@ export class PieceCoordinates {
         let outrow = output[1];
         
         let index = this.findIndex(incol, inrow, rank, alignment);
-        if(index == null)
+        if (index == null)
             return false;
         this.#coordinates[alignment][rank][index] = [outcol, outrow];
         return true;
@@ -46,7 +46,7 @@ export class PieceCoordinates {
         let index = this.findIndex(col, row, rank, alignment);
         if(index == null)
             return false;
-        this.#coordinates[alignment][rank].splice(index, index);
+        this.#coordinates[alignment][rank].splice(index, 1);
         return true;
     }
 

--- a/src/game-objects/test/chessboard.test.js
+++ b/src/game-objects/test/chessboard.test.js
@@ -338,10 +338,12 @@ describe("", () => {
         tiles.boardState.addPiece(6, 5, KING, COMPUTER);
         click(6, 6);
         expect(tiles.chessTiles[6][5].fillColor).toBe(THREAT_COLOR);
+        click(6, 6);
         for (let i = 0; i < 8; i++)
             for (let j = 0; j < 8; j++)
                 if (tiles.boardState.isOccupied(i, j))
                     tiles.boardState.destroyPiece(i, j);
+        tiles.boardState.addPiece(7, 7, KING, PLAYER);
         tiles.boardState.addPiece(3, 3, QUEEN, PLAYER);
         click(3, 3);
         for (let i = 0; i < 8; i++)


### PR DESCRIPTION
1. Fix splice function in piece-coordinates.js deleting 'index' number of elements instead of exactly 1 (as it should)
2. Fix typo in spawnNextWave function where 'length' was mistyped as 'Length'
3. Miscellaneous commenting & code shortening (same functionality but more concise)