### PR TITLE
Color mode added in Settings button + testing to be pushed here

### DIFF
--- a/src/game-objects/constants.js
+++ b/src/game-objects/constants.js
@@ -68,6 +68,20 @@ const PLAYER = "W"; // player alignment
 const COMPUTER = "B"; // computer alignment
 
 const EN_PASSANT_TOKEN = "en passant"; // en passant token
+export const COLOR_THEMES = {
+	default: {primary: "#000000", secondary: "#FFFFFF"},
+	dark: {primary: "#1B1B1B", secondary: "#848482"},
+	light: {primary: "#FFFFFF", secondary: "#C0C0C0"},
+};
+
+function applyColors(selectedPalette) {
+	const colors = COLOR_THEMES[selectedPalette] || COLOR_THEMES.default;
+	document.documentElement.style.setProperty("--primary-chess-color", colors.primary);
+	document.documentElement.style.setProperty("--secondary-chess-color", colors.secondary);
+}
+
+// Call the function when needed
+applyColors("default"); // Change "default" to a dynamic value if needed
 
 export function isSamePoint([col1, row1], [col2, row2]) {
 	return col1 == col2 && row1 == row2;

--- a/src/game/scenes/Settings.test.js
+++ b/src/game/scenes/Settings.test.js
@@ -1,4 +1,4 @@
-import { Settings } from "./Settings"; // Import the Settings scene
+import { Settings } from "./settings"; // Import the Settings scene
 
 describe("Settings Scene", () => {
     let scene;
@@ -32,7 +32,7 @@ describe("Settings Scene", () => {
     
     // developer mode?? sprint 3 
     //color code non implementation here?
-    
+
     test("should create the Color Palette label", () => {
         expect(scene.add.text).toHaveBeenCalledWith(
             200, 170, "Color Palette:", expect.any(Object)

--- a/src/game/scenes/Settings.test.js
+++ b/src/game/scenes/Settings.test.js
@@ -10,43 +10,51 @@ describe("Settings Scene", () => {
         scene.cameras = { main: { setBackgroundColor: jest.fn() } };
         scene.scene = { stop: jest.fn(), restart: jest.fn() };
 
-        // Properly mock Phaser’s `this.add.text()` method, ensuring `.setInteractive()` and `.on()` are available
+        // Properly mock `this.add.text()` for text objects (titles, buttons)
         scene.add = {
-            text: jest.fn((x, y, text, style) => {
-                const mockTextObject = {
-                    x,
-                    y,
-                    text,
-                    style,
-                    setInteractive: jest.fn().mockReturnThis(), // Ensure method chaining works
-                    on: jest.fn().mockReturnThis(), // Ensure event listeners are tracked
-                    setOrigin: jest.fn().mockReturnThis(),
-                    setDepth: jest.fn().mockReturnThis(),
-                };
-                return mockTextObject;
-            }),
+            text: jest.fn((x, y, text, style) => ({
+                x, y, text, style,
+                setInteractive: jest.fn().mockReturnThis(),
+                on: jest.fn().mockReturnThis(),
+                setOrigin: jest.fn().mockReturnThis(),
+            })),
+            rectangle: jest.fn().mockReturnValue({ setOrigin: jest.fn() }),
         };
 
         scene.create(); // Simulate scene creation
     });
 
     test("should create the Settings title", () => {
-        expect(scene.add.text).toHaveBeenCalledWith(expect.any(Number), expect.any(Number), "SETTINGS", expect.any(Object));
+        expect(scene.add.text).toHaveBeenCalledWith(
+            expect.any(Number), 100, "SETTINGS", expect.any(Object)
+        );
     });
 
-    //developer mode to be added later in sprint 3
-    // color buttons??
+    test("should create the Color Palette label", () => {
+        expect(scene.add.text).toHaveBeenCalledWith(
+            200, 170, "Color Palette:", expect.any(Object)
+        );
+    });
+
+    test("should create theme selection buttons", () => {
+        const palettes = ["default", "dark", "light"];
+        palettes.forEach((palette) => {
+            expect(scene.add.text).toHaveBeenCalledWith(
+                expect.any(Number), expect.any(Number), palette, expect.any(Object)
+            );
+        });
+    });
 
     test("should create the Close button", () => {
-        expect(scene.add.text).toHaveBeenCalledWith(expect.any(Number), expect.any(Number), "Close", expect.any(Object));
+        expect(scene.add.text).toHaveBeenCalledWith(
+            expect.any(Number), expect.any(Number), "Close Settings", expect.any(Object)
+        );
     });
 
     test("should make the Close button interactive", () => {
-        // Find the Close button in the mock
-        const closeButton = scene.add.text.mock.results.find(result => result.value.text === "Close")?.value;
-
-        expect(closeButton).toBeDefined(); // Ensure the button exists
-        expect(closeButton.setInteractive).toHaveBeenCalled(); // Check if interactive
-        expect(closeButton.on).toHaveBeenCalledWith("pointerdown", expect.any(Function)); // Check click event
+        const closeButton = scene.add.text.mock.results.find(result => result.value.text === "Close Settings")?.value;
+        expect(closeButton).toBeDefined();
+        expect(closeButton.setInteractive).toHaveBeenCalled();
+        expect(closeButton.on).toHaveBeenCalledWith("pointerdown", expect.any(Function));
     });
 });

--- a/src/game/scenes/Settings.test.js
+++ b/src/game/scenes/Settings.test.js
@@ -10,7 +10,7 @@ describe("Settings Scene", () => {
         scene.cameras = { main: { setBackgroundColor: jest.fn() } };
         scene.scene = { stop: jest.fn(), restart: jest.fn() };
 
-        // ✅ Properly mock Phaser’s `this.add.text()` method, ensuring `.setInteractive()` and `.on()` are available
+        // Properly mock Phaser’s `this.add.text()` method, ensuring `.setInteractive()` and `.on()` are available
         scene.add = {
             text: jest.fn((x, y, text, style) => {
                 const mockTextObject = {
@@ -34,12 +34,15 @@ describe("Settings Scene", () => {
         expect(scene.add.text).toHaveBeenCalledWith(expect.any(Number), expect.any(Number), "SETTINGS", expect.any(Object));
     });
 
+    //developer mode to be added later in sprint 3
+    // color buttons??
+
     test("should create the Close button", () => {
         expect(scene.add.text).toHaveBeenCalledWith(expect.any(Number), expect.any(Number), "Close", expect.any(Object));
     });
 
     test("should make the Close button interactive", () => {
-        // ✅ Find the Close button in the mock
+        // Find the Close button in the mock
         const closeButton = scene.add.text.mock.results.find(result => result.value.text === "Close")?.value;
 
         expect(closeButton).toBeDefined(); // Ensure the button exists

--- a/src/game/scenes/Settings.test.js
+++ b/src/game/scenes/Settings.test.js
@@ -29,7 +29,10 @@ describe("Settings Scene", () => {
             expect.any(Number), 100, "SETTINGS", expect.any(Object)
         );
     });
-
+    
+    // developer mode?? sprint 3 
+    //color code non implementation here?
+    
     test("should create the Color Palette label", () => {
         expect(scene.add.text).toHaveBeenCalledWith(
             200, 170, "Color Palette:", expect.any(Object)

--- a/src/game/scenes/Settings.test.js
+++ b/src/game/scenes/Settings.test.js
@@ -1,65 +1,49 @@
-import { Settings } from "./settings"; // Import the settings scene
+import { Settings } from "./Settings"; // Import the Settings scene
 
-// We are mocking the Start Scene instead of running the whole game loop
-// Running the whole game loop takes too long and will result in the test timing out and failing
-describe("settings Scene", () => {
+describe("Settings Scene", () => {
     let scene;
 
     beforeEach(() => {
-        // Setup: Create a new instance of the Start scene for each test
         scene = new Settings();
 
-        // Mock the cameras object since it is normally initialized by Phaser
-        scene.cameras = {
-            main: {
-            },
-        };
+        // Mock Phaser dependencies
+        scene.cameras = { main: { setBackgroundColor: jest.fn() } };
+        scene.scene = { stop: jest.fn(), restart: jest.fn() };
 
-        // Mock the children array to simulate the scene objects like buttons and text.
-        scene.children = {
-            // Mock the getChildren method, which is responsible for fetching the scene's children objects (e.g., text, buttons)
-            getChildren: jest.fn().mockReturnValue([
-                // Mock the main title text object with expected properties
-                { text: "settings mode", x: 512, y: 490 },
-                // Mock the close rules button, ensuring it has a text and is interactable
-                { text: "Close settings", input: { enabled: true } },
-            ]),
-        };
-
-        // Mock the add.text method for creating text objects in the scene
+        // ✅ Properly mock Phaser’s `this.add.text()` method, ensuring `.setInteractive()` and `.on()` are available
         scene.add = {
-            text: jest.fn().mockReturnValue({
-                // Mock the method chaining typically used when creating Phaser text objects
-                setOrigin: jest.fn(),
-                setDepth: jest.fn(),
-                setInteractive: jest.fn(),
-                on: jest.fn(), // Mock event listener attachment
+            text: jest.fn((x, y, text, style) => {
+                const mockTextObject = {
+                    x,
+                    y,
+                    text,
+                    style,
+                    setInteractive: jest.fn().mockReturnThis(), // Ensure method chaining works
+                    on: jest.fn().mockReturnThis(), // Ensure event listeners are tracked
+                    setOrigin: jest.fn().mockReturnThis(),
+                    setDepth: jest.fn().mockReturnThis(),
+                };
+                return mockTextObject;
             }),
         };
+
+        scene.create(); // Simulate scene creation
     });
 
-    // Test to verify that the main title text object is created properly
-    test("text objects should be created", () => {
-        // Find the text object with the correct text value from the mocked children array
-        const titleText = scene.children
-            .getChildren()
-            .find((child) => child.text === "settings mode");
-
-        // Assertions to check if the title text is created and its properties are correct
-        expect(titleText).toBeDefined(); // Ensure the title text exists
-        expect(titleText.x).toBe(512); // Ensure its x-position is correct
-        expect(titleText.y).toBe(490); // Ensure its y-position is correct
+    test("should create the Settings title", () => {
+        expect(scene.add.text).toHaveBeenCalledWith(expect.any(Number), expect.any(Number), "SETTINGS", expect.any(Object));
     });
 
-    // Test to verify that the close rules button is created and is interactive
-    test("close settings button should be created and interactive", () => {
-        // Find the start button from the mocked children
-        const closeSettingsButton = scene.children
-            .getChildren()
-            .find((child) => child.text === "Close settings");
+    test("should create the Close button", () => {
+        expect(scene.add.text).toHaveBeenCalledWith(expect.any(Number), expect.any(Number), "Close", expect.any(Object));
+    });
 
-        // Assertions to check if the start button exists and is interactive
-        expect(closeSettingsButton).toBeDefined(); // Ensure the button exists
-        expect(closeSettingsButton.input.enabled).toBe(true); // Ensure the button is interactive (enabled)
+    test("should make the Close button interactive", () => {
+        // ✅ Find the Close button in the mock
+        const closeButton = scene.add.text.mock.results.find(result => result.value.text === "Close")?.value;
+
+        expect(closeButton).toBeDefined(); // Ensure the button exists
+        expect(closeButton.setInteractive).toHaveBeenCalled(); // Check if interactive
+        expect(closeButton.on).toHaveBeenCalledWith("pointerdown", expect.any(Function)); // Check click event
     });
 });

--- a/src/game/scenes/settings.html
+++ b/src/game/scenes/settings.html
@@ -1,36 +1,90 @@
-DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Settings</title>
-    <link rel="stylesheet" href="styles.css"> <!-- ✅ Add a CSS file for styling -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chess Piece Mode Toggle</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+    }
+    button {
+      padding: 10px 20px;
+      font-size: 16px;
+      margin: 10px;
+    }
+    .chess-piece {
+      width: 50px;
+      height: 50px;
+      margin: 5px;
+    }
+  </style>
 </head>
 <body>
+  <h1>Chess Piece Mode Toggle</h1>
 
-    <div id="settingsContainer">
-        <div id="settingsMenu">
-            <fieldset>
-                <legend>Game Settings</legend>
+  <!-- Mode buttons -->
+  <button id="defaultModeBtn">Default Mode</button>
+  <button id="lightModeBtn">Light Mode</button>
+  <button id="darkModeBtn">Dark Mode</button>
 
-                <label for="colorPaletteSelect">Select Chess Piece Color:</label>
-                <select id="colorPaletteSelect">
-                    <option value="default">Black & White (Default)</option>
-                    <option value="dark">Eerie Black & Battleship Gray (Dark)</option>
-                    <option value="light">White & Silver (Light)</option>
-                </select>
+  <!-- Chess pieces (images) -->
+  <div id="chessPieces">
+    <img id="pawn1" class="chess-piece" src="assets/default/pawn.png" alt="pawn1">
+    <img id="pawn2" class="chess-piece" src="assets/default/pawn.png" alt="pawn2">
+    <img id="rook1" class="chess-piece" src="assets/default/rook.png" alt="rook1">
+    <img id="rook2" class="chess-piece" src="assets/default/rook.png" alt="rook2">
+    <!-- Add other pieces here like knights, bishops, etc. -->
+  </div>
 
-                <br>
+  <script>
+    // Grab the buttons and pieces
+    const defaultModeBtn = document.getElementById("defaultModeBtn");
+    const lightModeBtn = document.getElementById("lightModeBtn");
+    const darkModeBtn = document.getElementById("darkModeBtn");
+    const chessPieces = document.querySelectorAll(".chess-piece");
 
-                <label for="devModeToggle">Enable Developer Mode:</label>
-                <input type="checkbox" id="devModeToggle">
+    // Function to switch to the default mode
+    function switchToDefault() {
+      console.log("Default Mode selected");
+      chessPieces.forEach(piece => {
+        piece.src = "assets/default/" + piece.alt.toLowerCase() + ".png"; // Update images
+      });
+      localStorage.setItem("mode", "default"); // Store mode in localStorage
+    }
 
-            </fieldset>
+    // Function to switch to light mode
+    function switchToLight() {
+      console.log("Light Mode selected");
+      chessPieces.forEach(piece => {
+        piece.src = "assets/light/" + piece.alt.toLowerCase() + ".png"; // Update images
+      });
+      localStorage.setItem("mode", "light"); // Store mode in localStorage
+    }
 
-            <button id="closeSettings">Close</button>
-        </div>
-    </div>
+    // Function to switch to dark mode
+    function switchToDark() {
+      console.log("Dark Mode selected");
+      chessPieces.forEach(piece => {
+        piece.src = "assets/dark/" + piece.alt.toLowerCase() + ".png"; // Update images
+      });
+      localStorage.setItem("mode", "dark"); // Store mode in localStorage
+    }
 
-    <script src="settingsButton.js"></script> <!-- ✅ Ensure correct path -->
+    // Add event listeners to the buttons
+    defaultModeBtn.addEventListener("click", switchToDefault);
+    lightModeBtn.addEventListener("click", switchToLight);
+    darkModeBtn.addEventListener("click", switchToDark);
+
+    // Load saved mode from localStorage when the page loads
+    const savedMode = localStorage.getItem("mode");
+    if (savedMode === "light") {
+      lightModeBtn.click(); // Simulate click for light mode
+    } else if (savedMode === "dark") {
+      darkModeBtn.click(); // Simulate click for dark mode
+    } else {
+      defaultModeBtn.click(); // Simulate click for default mode if no mode is saved
+    }
+  </script>
 </body>
 </html>

--- a/src/game/scenes/settings.html
+++ b/src/game/scenes/settings.html
@@ -1,0 +1,36 @@
+DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Settings</title>
+    <link rel="stylesheet" href="styles.css"> <!-- ✅ Add a CSS file for styling -->
+</head>
+<body>
+
+    <div id="settingsContainer">
+        <div id="settingsMenu">
+            <fieldset>
+                <legend>Game Settings</legend>
+
+                <label for="colorPaletteSelect">Select Chess Piece Color:</label>
+                <select id="colorPaletteSelect">
+                    <option value="default">Black & White (Default)</option>
+                    <option value="dark">Eerie Black & Battleship Gray (Dark)</option>
+                    <option value="light">White & Silver (Light)</option>
+                </select>
+
+                <br>
+
+                <label for="devModeToggle">Enable Developer Mode:</label>
+                <input type="checkbox" id="devModeToggle">
+
+            </fieldset>
+
+            <button id="closeSettings">Close</button>
+        </div>
+    </div>
+
+    <script src="settingsButton.js"></script> <!-- ✅ Ensure correct path -->
+</body>
+</html>

--- a/src/game/scenes/settings.js
+++ b/src/game/scenes/settings.js
@@ -1,4 +1,4 @@
-import Phaser from "phaser"; // ✅ Ensure Phaser is imported
+import Phaser from "phaser";
 import {COLOR_THEMES} from "../../game-objects/constants.js";
 
 export class Settings extends Phaser.Scene {
@@ -7,54 +7,77 @@ export class Settings extends Phaser.Scene {
 	}
 
 	create() {
-		// console.log("Settings Scene Loaded!"); // ❌ Removed to avoid 'no-console'
+		// Semi-transparent overlay background
+		const overlay = this.add.rectangle(
+			this.cameras.main.width / 2,
+			this.cameras.main.height / 2,
+			this.cameras.main.width * 0.8,
+			this.cameras.main.height * 0.7,
+			0x000000,
+			0.7 // Transparency level
+		);
+		overlay.setOrigin(0.5, 0.5);
 
-		this.cameras.main.setBackgroundColor("#d87b40"); // Match Rules page
+		// SETTINGS Title
+		this.add
+			.text(this.cameras.main.width / 2, 100, "SETTINGS", {
+				fontSize: "32px",
+				fill: "#f28d3e",
+				fontFamily: "Press Start 2P",
+			})
+			.setOrigin(0.5);
 
-		this.add.text(150, 50, "SETTINGS", {
-			fontSize: "32px",
-			fill: "#fff",
-			fontFamily: "Press Start 2P",
-		});
-
-		// 🎨 Theme Selection
-		this.add.text(100, 150, "Color Palette:", {fontSize: "20px", fill: "#fff"});
+		// Color Palette Section
+		this.add.text(200, 170, "Color Palette:", {fontSize: "20px", fill: "#fff"});
 
 		const palettes = ["default", "dark", "light"];
-		let yOffset = 200;
+		let yOffset = 220;
 
 		palettes.forEach((palette) => {
 			this.add
-				.text(120, yOffset, palette, {
+				.text(220, yOffset, palette, {
 					fontSize: "18px",
-					fill: "#aaa",
+					fill: "#f28d3e",
 					backgroundColor: "#333",
 					padding: {x: 10, y: 5},
 				})
 				.setInteractive()
 				.on("pointerdown", () => {
-					// console.log(`Applying color theme: ${palette}`); // ❌ Removed 'no-console'
 					localStorage.setItem("selectedPalette", palette);
 					this.applyColorTheme(palette);
-					this.scene.restart(); // 🔄 Refresh
+					this.scene.restart(); // Refresh scene
 				});
 
 			yOffset += 50;
 		});
 
-		// ❌ Close Button
+		// Dev Mode Toggle Button
+		// this.add
+		//   .text(200, yOffset, "Toggle Dev Mode", {
+		//     fontSize: "18px",
+		//     fill: "#f28d3e",
+		//     backgroundColor: "#333",
+		//     padding: { x: 10, y: 5 },
+		//   })
+		//   .setInteractive()
+		//   .on("pointerdown", () => {
+		//     toggleDev();
+		//   });
+
+		// yOffset += 50;
+
+		// Close Button (Same Style as "Close Rules")
 		this.add
-			.text(400, 100, "Close", {
-				fontSize: "24px",
-				fill: "#f00",
-				backgroundColor: "#333",
-				padding: {x: 10, y: 5},
+			.text(this.cameras.main.width / 2, this.cameras.main.height - 100, "Close Settings", {
+				fontSize: "20px",
+				fill: "#fff",
+				backgroundColor: "#f28d3e",
+				padding: {x: 20, y: 10},
 			})
+			.setOrigin(0.5)
 			.setInteractive()
 			.on("pointerdown", () => {
-				// console.log("Closing settings..."); // ❌ Removed 'no-console'
 				this.scene.stop("Settings");
-				//	this.scene.start("MainGame");
 			});
 
 		// Apply stored settings
@@ -66,12 +89,10 @@ export class Settings extends Phaser.Scene {
 		const colors = COLOR_THEMES[selectedPalette];
 
 		if (!colors) {
-			return; // ✅ Now properly wrapped in curly braces
+			return;
 		}
 
 		document.documentElement.style.setProperty("--primary-chess-color", colors.primary);
 		document.documentElement.style.setProperty("--secondary-chess-color", colors.secondary);
-
-		// console.log(`Color theme applied: ${selectedPalette}`); // ❌ Removed 'no-console'
 	}
 }

--- a/src/game/scenes/settings.js
+++ b/src/game/scenes/settings.js
@@ -1,67 +1,77 @@
-import {Scene} from "phaser";
-import {EventBus} from "../EventBus";
+import Phaser from "phaser"; // ✅ Ensure Phaser is imported
+import {COLOR_THEMES} from "../../game-objects/constants.js";
 
-export class Settings extends Scene {
+export class Settings extends Phaser.Scene {
 	constructor() {
-		super("Settings");
-	}
-
-	preload() {
-		this.load.setPath("assets");
-		this.load.image("star", "star.png");
-		this.load.image("background", "bg.png");
+		super({key: "Settings"});
 	}
 
 	create() {
-		// Creates a visual background that also blocks input on the scene underneath
-		const bg = this.add.rectangle(625, 384, 1250, 768, 0x00ff00, 0.5);
-		bg.setDepth(50);
+		// console.log("Settings Scene Loaded!"); // ❌ Removed to avoid 'no-console'
 
-		// Placeholder visual elements
-		this.add.image(512, 384, "background").alpha = 0.5;
-		this.add.image(512, 350, "star").setDepth(100);
+		this.cameras.main.setBackgroundColor("#d87b40"); // Match Rules page
+
+		this.add.text(150, 50, "SETTINGS", {
+			fontSize: "32px",
+			fill: "#fff",
+			fontFamily: "Press Start 2P",
+		});
+
+		// 🎨 Theme Selection
+		this.add.text(100, 150, "Color Palette:", {fontSize: "20px", fill: "#fff"});
+
+		const palettes = ["default", "dark", "light"];
+		let yOffset = 200;
+
+		palettes.forEach((palette) => {
+			this.add
+				.text(120, yOffset, palette, {
+					fontSize: "18px",
+					fill: "#aaa",
+					backgroundColor: "#333",
+					padding: {x: 10, y: 5},
+				})
+				.setInteractive()
+				.on("pointerdown", () => {
+					// console.log(`Applying color theme: ${palette}`); // ❌ Removed 'no-console'
+					localStorage.setItem("selectedPalette", palette);
+					this.applyColorTheme(palette);
+					this.scene.restart(); // 🔄 Refresh
+				});
+
+			yOffset += 50;
+		});
+
+		// ❌ Close Button
 		this.add
-			.text(512, 490, "Settings mode", {
-				fontFamily: "purple",
-				fontSize: 38,
-				color: "#ffffff",
-				stroke: "#000000",
-				strokeThickness: 8,
-				align: "center",
+			.text(400, 100, "Close", {
+				fontSize: "24px",
+				fill: "#f00",
+				backgroundColor: "#333",
+				padding: {x: 10, y: 5},
 			})
-			.setOrigin(0.5)
-			.setDepth(100);
-
-		const closeButton = this.add.text(100, 100, "Close Settings", {
-			fill: "#0099ff",
-			backgroundColor: "#ffff",
-			padding: {left: 20, right: 20, top: 10, bottom: 10},
-		});
-
-		closeButton.setOrigin(0.5);
-		closeButton.setPosition(625, 600);
-		closeButton.setInteractive();
-		closeButton.on(
-			"pointerdown",
-			function () {
+			.setInteractive()
+			.on("pointerdown", () => {
+				// console.log("Closing settings..."); // ❌ Removed 'no-console'
 				this.scene.stop("Settings");
-			},
-			this
-		);
-		closeButton.setDepth(100);
+				//	this.scene.start("MainGame");
+			});
 
-		// When the pointer hovers over the button, scale it up
-		closeButton.on("pointerover", () => {
-			closeButton.setScale(1.2);
-		});
+		// Apply stored settings
+		const savedPalette = localStorage.getItem("selectedPalette") || "default";
+		this.applyColorTheme(savedPalette);
+	}
 
-		// When the pointer moves away from the button, reset the scale to normal
-		closeButton.on("pointerout", () => {
-			closeButton.setScale(1);
-		});
+	applyColorTheme(selectedPalette) {
+		const colors = COLOR_THEMES[selectedPalette];
 
-		bg.setInteractive();
+		if (!colors) {
+			return; // ✅ Now properly wrapped in curly braces
+		}
 
-		EventBus.emit("current-scene-ready", this);
+		document.documentElement.style.setProperty("--primary-chess-color", colors.primary);
+		document.documentElement.style.setProperty("--secondary-chess-color", colors.secondary);
+
+		// console.log(`Color theme applied: ${selectedPalette}`); // ❌ Removed 'no-console'
 	}
 }

--- a/src/game/scenes/settings.js
+++ b/src/game/scenes/settings.js
@@ -1,67 +1,67 @@
-import { Scene } from "phaser";
-import { EventBus } from "../EventBus";
+import {Scene} from "phaser";
+import {EventBus} from "../EventBus";
 
 export class Settings extends Scene {
-    constructor() {
-        super("Settings");
-    }
+	constructor() {
+		super("Settings");
+	}
 
-    preload() {
-        this.load.setPath("assets");
-        this.load.image("star", "star.png");
-        this.load.image("background", "bg.png");
-    }
+	preload() {
+		this.load.setPath("assets");
+		this.load.image("star", "star.png");
+		this.load.image("background", "bg.png");
+	}
 
-    create() {
-        // Creates a visual background that also blocks input on the scene underneath
-        const bg = this.add.rectangle(625, 384, 1250, 768, 0x00ff00, 0.5);
-        bg.setDepth(50);
+	create() {
+		// Creates a visual background that also blocks input on the scene underneath
+		const bg = this.add.rectangle(625, 384, 1250, 768, 0x00ff00, 0.5);
+		bg.setDepth(50);
 
-        // Placeholder visual elements
-        this.add.image(512, 384, "background").alpha = 0.5;
-        this.add.image(512, 350, "star").setDepth(100);
-        this.add
-            .text(512, 490, "Settings mode", {
-                fontFamily: "Arial Black",
-                fontSize: 38,
-                color: "#ffffff",
-                stroke: "#000000",
-                strokeThickness: 8,
-                align: "center",
-            })
-            .setOrigin(0.5)
-            .setDepth(100);
+		// Placeholder visual elements
+		this.add.image(512, 384, "background").alpha = 0.5;
+		this.add.image(512, 350, "star").setDepth(100);
+		this.add
+			.text(512, 490, "Settings mode", {
+				fontFamily: "purple",
+				fontSize: 38,
+				color: "#ffffff",
+				stroke: "#000000",
+				strokeThickness: 8,
+				align: "center",
+			})
+			.setOrigin(0.5)
+			.setDepth(100);
 
-        const closeButton = this.add.text(100, 100, "Close Settings", {
-            fill: "#0099ff",
-            backgroundColor: "#ffff",
-            padding: { left: 20, right: 20, top: 10, bottom: 10 },
-        });
+		const closeButton = this.add.text(100, 100, "Close Settings", {
+			fill: "#0099ff",
+			backgroundColor: "#ffff",
+			padding: {left: 20, right: 20, top: 10, bottom: 10},
+		});
 
-        closeButton.setOrigin(0.5);
-        closeButton.setPosition(625, 600);
-        closeButton.setInteractive();
-        closeButton.on(
-            "pointerdown",
-            function () {
-                this.scene.stop("Settings");
-            },
-            this
-        );
-        closeButton.setDepth(100);
+		closeButton.setOrigin(0.5);
+		closeButton.setPosition(625, 600);
+		closeButton.setInteractive();
+		closeButton.on(
+			"pointerdown",
+			function () {
+				this.scene.stop("Settings");
+			},
+			this
+		);
+		closeButton.setDepth(100);
 
-        // When the pointer hovers over the button, scale it up
-        closeButton.on("pointerover", () => {
-            closeButton.setScale(1.2);
-        });
+		// When the pointer hovers over the button, scale it up
+		closeButton.on("pointerover", () => {
+			closeButton.setScale(1.2);
+		});
 
-        // When the pointer moves away from the button, reset the scale to normal
-        closeButton.on("pointerout", () => {
-            closeButton.setScale(1);
-        });
+		// When the pointer moves away from the button, reset the scale to normal
+		closeButton.on("pointerout", () => {
+			closeButton.setScale(1);
+		});
 
-        bg.setInteractive();
+		bg.setInteractive();
 
-        EventBus.emit("current-scene-ready", this);
-    }
+		EventBus.emit("current-scene-ready", this);
+	}
 }


### PR DESCRIPTION
In Sprint 2, we added the color mode button in settings.html, but since the chess piece images aren’t in the assets folder yet, the button doesn’t actually change anything right now. The setup is in place, though, so once we add the images in Sprint 3, the button will work as expected and update the chess piece colors.
For now, the Dev Mode button is on the main game screen. In the next sprint, once the assets are in place, the color mode feature will be fully functional.


testing was done here