### PR TITLE
fixed issue with gameOver screen not having game as background

### DIFF
--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -356,7 +356,7 @@ export class ChessTiles {
                     if (!this.scene.scene.get("GameOver"))
                         this.scene.scene.add("GameOver", module.GameOver);
                     // Start the GameOver scene
-                    this.scene.scene.start("GameOver");
+                    this.scene.scene.launch("GameOver");
                 });
     }
 

--- a/src/game-objects/test/chessboard.test.js
+++ b/src/game-objects/test/chessboard.test.js
@@ -82,6 +82,7 @@ describe("", () => {
             get: jest.fn((name) => {}),
             add: jest.fn((name, scene) => {}),
             start: jest.fn((name) => {}),
+            launch: jest.fn((name) => {}),
         }
 
         // Mock the add.rectangle & add.text & add.existing methods


### PR DESCRIPTION
Changed `this.scene.scene.start("GameOver");` on ChessTiles line 359 to `this.scene.scene.launch("GameOver");` so it doesn't kill the background scene in the ToggleTurn method.

Technically this should be its own branch or something, but its really small and I forgot to switch branches before committing this.