### PR TITLE
Kaydee/Wave Improvements

### DIFF
--- a/src/game-objects/board-state.js
+++ b/src/game-objects/board-state.js
@@ -23,7 +23,11 @@ export class BoardState {
 
 		// Initialize Player/Computer (white/black) pieces
 		this.initializePieces(PLAYER);
-		this.initializePieces(COMPUTER);
+		// this.initializePieces(COMPUTER);
+
+		// Add 4 pawns as the first generic wave
+		for (let i = 2; i < 6; i++)
+			this.addPiece(i, 1, PAWN, COMPUTER);
 	}
 
 	// initialize player pieces (and computer pieces for testing purposes)

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -45,7 +45,8 @@ export class ChessTiles {
         this.temp;              // temporary storage of coordinate & color; list of dictionaries of {'xy':[#,#],'color':color}
         this.threats;           // temporary storage of threats to chess piece, list of lists of [#,#]
 
-        this.turnsUntilNextWave = 13;
+        this.baseTurnsUntilNextWave = 13;
+        this.turnsUntilNextWave = this.baseTurnsUntilNextWave;
         this.waveSpawnBudget = 4;
 
         this.promotionCol;      // temporary storage of column of piece to promote
@@ -376,7 +377,7 @@ export class ChessTiles {
         try {
             // console.log("NEW WAVE SPAWNS!");
             // Reset turn counter
-            this.turnsUntilNextWave = 8;
+            this.turnsUntilNextWave = this.baseTurnsUntilNextWave;
 
             // Randomly order what priority of pieces to go through to prevent a universal bias
             let piecePriority = this.getPiecePriorityOrder();

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -45,8 +45,8 @@ export class ChessTiles {
         this.temp;              // temporary storage of coordinate & color; list of dictionaries of {'xy':[#,#],'color':color}
         this.threats;           // temporary storage of threats to chess piece, list of lists of [#,#]
 
-        this.turnsUntilNextWave = 8;
-        this.waveSpawnBudget = 8;
+        this.turnsUntilNextWave = 13;
+        this.waveSpawnBudget = 4;
 
         this.promotionCol;      // temporary storage of column of piece to promote
         this.promotionRow;      // temporary storage of row of piece to promote
@@ -428,7 +428,7 @@ export class ChessTiles {
             window.alert("Error with new wave: "+ex.message);
         }
 
-        this.waveSpawnBudget += 8;
+        this.waveSpawnBudget += 2;
         incrementGlobalWaves();
     }
 
@@ -463,8 +463,8 @@ export class ChessTiles {
 
     // Get a random order of pieces to process to prevent a universal bias
     getPiecePriorityOrder() {
-        // This order doesn't matter
-        let piecePriority = [ QUEEN, PAWN, BISHOP, ROOK, KNIGHT ];
+        // This order doesn't matter (gets randomized)
+        let piecePriority = [ QUEEN, BISHOP, ROOK, KNIGHT ];
 
         // Sort it randomly
         let currentIndex = piecePriority.length;
@@ -473,6 +473,9 @@ export class ChessTiles {
             currentIndex--;
             [piecePriority[currentIndex], piecePriority[randomIndex]] = [piecePriority[randomIndex], piecePriority[currentIndex]];
         }
+        
+        // We wanted less pawns, so append it to the end to always be the lowest priority
+        piecePriority.push(PAWN);
 
         return piecePriority;
     }
@@ -619,6 +622,12 @@ export class ChessTiles {
         this.futureMoves= new ChessGameState(this.boardState);
         // this.futureMoves.getBestMove();
         // this.futureMoves.sendMove([0,1],[0,3]);
+
+        try {
         this.futureMoves.getRandomMove();
+        } catch (ex) {
+            window.alert("Error while getting random move: "+ex.message);
+        }
+        this.futureMoves=null;
     }
 }

--- a/src/game-objects/computer-logic.js
+++ b/src/game-objects/computer-logic.js
@@ -185,7 +185,7 @@ export class ChessGameState {
 		let moves;
 
 		while (!pieceFound) {
-			pieceToMove = this.getRandomInt(0, coordinates.length - 1); // get random piece
+			pieceToMove = this.getRandomInt(0, coordinates.length); // get random piece
 			// console.log(this.theBoardState.searchMoves(coordinates[pieceToMove][0], coordinates[pieceToMove][1]));
 			// let theMoves = this.theBoardState.searchMoves(coordinates[pieceToMove][0], coordinates[pieceToMove][1]);
 			// console.log(theMoves);
@@ -196,7 +196,7 @@ export class ChessGameState {
 			}
 		}
 		moves = this.theBoardState.searchMoves(coordinates[pieceToMove][0], coordinates[pieceToMove][1]);
-		const move = this.getRandomInt(0, moves.length - 1); // select random legal move that piece can make
+		const move = this.getRandomInt(0, moves.length); // select random legal move that piece can make
 		// console.log("Moves", moves[move]);
 
 		// console.log(coordinates[pieceToMove]);

--- a/src/game-objects/test/chessboard.test.js
+++ b/src/game-objects/test/chessboard.test.js
@@ -223,6 +223,11 @@ describe("", () => {
 
 		// Create ChessTiles object
 		tiles = new ChessTiles(scene);
+		
+		// Zap and reinstantiate computer pieces for tests
+		tiles.boardState.zapPieces(COMPUTER);
+		tiles.boardState.initializePieces(COMPUTER);
+
 		if (!dev_deadAI) dev_toggleAI(); // kills AI
 
 		// Trigger hover event where 'Start Game' button is
@@ -437,9 +442,11 @@ describe("", () => {
 		click(2, 2);
 		expect(globalMoves).toBe(3);
 		expect(globalPieces).toBe(2);
+
+		let turnCountDoubled = tiles.baseTurnsUntilNextWave * 2;
 		for (let i = 1; i < 100; i++) {
 			tiles.toggleTurn();
-			if (i % 16 == 0) expect(globalWaves).toBe(i / 16);
+			if (i % turnCountDoubled == 0) expect(globalWaves).toBe(i / turnCountDoubled);
 		}
 	});
 


### PR DESCRIPTION
This addresses issues #102 , #106, and #107 with the following changes to make the game more enjoyable to play:

- Changes the enemy's opening setup from a complete standard symmetrical set to a row of 4 Pawns
- Addresses a crash in cases where there are low move counts for the AI
- Lowers the amount of budget the AI has to spawn more pieces in a new wave
- Makes Pawns always the lowest priority piece to roll spawns for, making them much less frequent
- Increases the amount of turns needed to spawn the next wave from 8 to 13