### PR TITLE
Resize Texts & Images when the Window Dimension changes

### DIFF
--- a/src/game-objects/board-state.js
+++ b/src/game-objects/board-state.js
@@ -1,4 +1,4 @@
-import {TILE_SIZE, X_ANCHOR, Y_ANCHOR} from "./constants";
+import {TILE_SIZE, UNIT_HEIGHT, X_ANCHOR, Y_ANCHOR} from "./constants";
 import {PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING} from "./constants";
 import {PLAYER, COMPUTER} from "./constants";
 import {EN_PASSANT_TOKEN} from "./constants";
@@ -26,8 +26,16 @@ export class BoardState {
 		// this.initializePieces(COMPUTER);
 
 		// Add 4 pawns as the first generic wave
-		for (let i = 2; i < 6; i++)
-			this.addPiece(i, 1, PAWN, COMPUTER);
+		for (let i = 2; i < 6; i++) this.addPiece(i, 1, PAWN, COMPUTER);
+	}
+
+	resize() {
+		for (let i = 0; i < 8; i++)
+			for (let j = 0; j < 8; j++)
+				if (this.isOccupied(i, j)) {
+					this.#boardState[i][j].setPosition(X_ANCHOR + i * TILE_SIZE, Y_ANCHOR + j * TILE_SIZE);
+					this.#boardState[i][j].scale = UNIT_HEIGHT / 5;
+				}
 	}
 
 	// initialize player pieces (and computer pieces for testing purposes)
@@ -115,6 +123,8 @@ export class BoardState {
 			alignment,
 			[col, row]
 		);
+		this.#boardState[col][row].scale = UNIT_HEIGHT / 5;
+
 		this.#scene.add.existing(this.#boardState[col][row]);
 
 		this.#pieceCoordinates.addCoordinate(col, row, rank, alignment);
@@ -166,10 +176,9 @@ export class BoardState {
 
 	// Destroy all pieces of given alignment
 	zapPieces(alignment) {
-		for (let i = 0; i < 8; i++) {
+		for (let i = 0; i < 8; i++)
 			for (let j = 0; j < 8; j++)
 				if (this.isOccupied(i, j) && this.getAlignment(i, j) == alignment) this.destroyPiece(i, j);
-		}
 	}
 
 	// ================================================================

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -28,6 +28,8 @@ import {dev_alignment, dev_rank, dev_bamzap, dev_stopOn, dev_deadAI} from "./dev
 import {BAM, ZAP} from "./dev-buttons";
 import {DevButtons} from "./dev-buttons";
 
+import {fontsizeTexts} from "./constants";
+
 import {EventBus} from "../game/EventBus";
 
 export class ChessTiles {
@@ -68,7 +70,7 @@ export class ChessTiles {
 		this.isChecked; // is true if the current player's king is checked
 
 		// Set up stage behind (surrounding) chessboard
-		this.scene.add.rectangle(
+		this.stage = this.scene.add.rectangle(
 			X_ANCHOR + 3.5 * TILE_SIZE,
 			Y_ANCHOR + 3.5 * TILE_SIZE,
 			9 * TILE_SIZE,
@@ -149,6 +151,37 @@ export class ChessTiles {
 		this.boardState = new BoardState(this.scene, this.pieceCoordinates);
 		this.piecesTaken = new PiecesTaken(this.scene);
 		this.devButtons = new DevButtons(this.scene, this);
+	}
+
+	resize() {
+		this.stage.setPosition(X_ANCHOR + 3.5 * TILE_SIZE, Y_ANCHOR + 3.5 * TILE_SIZE);
+		this.stage.setSize(9 * TILE_SIZE, 9 * TILE_SIZE);
+		for (let i = 0; i < 4; i++)
+			for (let j = 0; j < 8; j++) {
+				fontsizeTexts(TILE_SIZE / 2, this.sideLights[i][j]);
+				switch (i) {
+					case 0: // [0,1][0~7] top & bottom rows of a~h
+						this.sideLights[i][j].setPosition(X_ANCHOR + j * TILE_SIZE, Y_ANCHOR - 0.75 * TILE_SIZE);
+						break;
+					case 1: // [0,1][0~7] top & bottom rows of a~h
+						this.sideLights[i][j].setPosition(X_ANCHOR + j * TILE_SIZE, Y_ANCHOR + 7.75 * TILE_SIZE);
+						break;
+					case 2: // [2,3][0~7] left & right columns of 1~8
+						this.sideLights[i][j].setPosition(X_ANCHOR - 0.75 * TILE_SIZE, Y_ANCHOR + j * TILE_SIZE);
+						break;
+					case 3: // [2,3][0~7] left & right columns of 1~8
+						this.sideLights[i][j].setPosition(X_ANCHOR + 7.75 * TILE_SIZE, Y_ANCHOR + j * TILE_SIZE);
+						break;
+				}
+			}
+		for (let i = 0; i < 8; i++)
+			for (let j = 0; j < 8; j++) {
+				this.chessTiles[i][j].setPosition(X_ANCHOR + i * TILE_SIZE, Y_ANCHOR + j * TILE_SIZE);
+				this.chessTiles[i][j].setSize(TILE_SIZE, TILE_SIZE);
+			}
+		this.boardState.resize();
+		this.devButtons.resize();
+		this.piecesTaken.resize();
 	}
 
 	// ================================================================

--- a/src/game-objects/constants.js
+++ b/src/game-objects/constants.js
@@ -1,8 +1,75 @@
-const TILE_SIZE = 80; // width & height of each tile
-const X_CENTER = 500;
-const Y_CENTER = 360;
-const X_ANCHOR = X_CENTER - 3.5 * TILE_SIZE; // x pixel of leftmost tile
-const Y_ANCHOR = Y_CENTER - 3.5 * TILE_SIZE; // y pixel of topmost tile
+let WINDOW_WIDTH;
+let WINDOW_HEIGHT;
+let CENTER_WIDTH;
+let CENTER_HEIGHT;
+let DOZEN_WIDTH;
+let DOZEN_HEIGHT;
+let UNIT_WIDTH;
+let UNIT_HEIGHT;
+
+let TILE_SIZE;
+let X_CENTER;
+let Y_CENTER;
+let X_ANCHOR;
+let Y_ANCHOR;
+
+let LEFT_X_CENTER;
+let RIGHT_X_CENTER;
+let LEFT_UNIT;
+let RIGHT_UNIT;
+
+resize_constants();
+
+export function configureButtons(...buttons) {
+	for (let button of buttons)
+		button
+			.setOrigin(0.5)
+			.setInteractive()
+			.on("pointerover", () => {
+				button.setScale(1.2); // Increase the scale (grow the button by 20%)
+			})
+			.on("pointerout", () => {
+				button.setScale(1); // Reset to original size
+			});
+}
+
+export function paddingTexts(width, height, ...texts) {
+	for (let text of texts) text.setPadding(width, height);
+}
+
+export function fontsizeTexts(fontSize, ...texts) {
+	for (let text of texts) text.setFontSize(fontSize);
+}
+
+export function resize_constants(scene = null) {
+	WINDOW_WIDTH = window.innerWidth;
+	WINDOW_HEIGHT = window.innerHeight;
+	if (WINDOW_WIDTH / WINDOW_HEIGHT > 21 / 9) WINDOW_WIDTH = (WINDOW_HEIGHT * 21) / 9;
+	else if (WINDOW_WIDTH / WINDOW_HEIGHT < 16 / 10) WINDOW_HEIGHT = (WINDOW_WIDTH / 16) * 10;
+
+	CENTER_WIDTH = WINDOW_WIDTH / 2;
+	CENTER_HEIGHT = WINDOW_HEIGHT / 2;
+	DOZEN_WIDTH = WINDOW_WIDTH / 12 ** 1;
+	DOZEN_HEIGHT = WINDOW_HEIGHT / 12 ** 1;
+	UNIT_WIDTH = WINDOW_WIDTH / 12 ** 2;
+	UNIT_HEIGHT = WINDOW_HEIGHT / 12 ** 2;
+
+	TILE_SIZE = WINDOW_HEIGHT / 9;
+	X_CENTER = 4 * DOZEN_HEIGHT + 2 * DOZEN_WIDTH;
+	Y_CENTER = CENTER_HEIGHT;
+	X_ANCHOR = X_CENTER - 2.5 * TILE_SIZE;
+	Y_ANCHOR = Y_CENTER - 3.5 * TILE_SIZE;
+
+	LEFT_X_CENTER = (X_ANCHOR - TILE_SIZE) / 2;
+	RIGHT_X_CENTER = (WINDOW_WIDTH + (X_ANCHOR + 8 * TILE_SIZE)) / 2;
+	LEFT_UNIT = LEFT_X_CENTER / 3;
+	RIGHT_UNIT = (WINDOW_WIDTH - RIGHT_X_CENTER) / 3;
+
+	if (scene != null) scene.scale.resize(WINDOW_WIDTH, WINDOW_HEIGHT);
+}
+
+export {WINDOW_WIDTH, WINDOW_HEIGHT, CENTER_WIDTH, CENTER_HEIGHT, DOZEN_WIDTH, DOZEN_HEIGHT, UNIT_WIDTH, UNIT_HEIGHT};
+export {LEFT_X_CENTER, RIGHT_X_CENTER, LEFT_UNIT, RIGHT_UNIT};
 
 const GRAY = "7D7F7C";
 const FAWN = "E5AA70";
@@ -100,6 +167,11 @@ export function isSamePoint([col1, row1], [col2, row2]) {
 
 export function dim2Array(dim1, dim2) {
 	return Array.from(Array(dim1), () => new Array(dim2));
+}
+
+export function zip(...arrays) {
+	const length = Math.min(...arrays.map((arr) => arr.length));
+	return Array.from({length}, (_, i) => arrays.map((arr) => arr[i]));
 }
 
 export {TILE_SIZE, X_CENTER, Y_CENTER, X_ANCHOR, Y_ANCHOR};

--- a/src/game-objects/dev-buttons.js
+++ b/src/game-objects/dev-buttons.js
@@ -1,7 +1,14 @@
-import {TILE_SIZE, X_ANCHOR, Y_ANCHOR} from "./constants";
 import {PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING} from "./constants";
 import {PLAYER, COMPUTER} from "./constants";
 import {CREAMHEX, ONYXHEX} from "./constants";
+
+import {configureButtons, paddingTexts, fontsizeTexts} from "./constants";
+import {LEFT_X_CENTER, LEFT_UNIT} from "./constants";
+
+const alignments = [PLAYER, COMPUTER];
+const alignment_names = ["white", "black"];
+const ranks = [PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING];
+const rank_names = ["♙", "♖", "♘", "♗", "♕", "♔"];
 
 const BAM = "BAM";
 const ZAP = "ZAP";
@@ -46,171 +53,161 @@ export function dev_toggleAI() {
 }
 
 export class DevButtons {
+	#scene;
+	#chessTiles;
+	#devButton;
+	#alignmentButtons = {};
+	#rankButtons = {};
+	#bamButton;
+	#boinkButton;
+	#zapButton;
+	#zoinkButton;
+	#flipButton;
+	#stopButton;
+	#aiButton;
 
-    #scene;
-    #chessTiles;
-    #devButton;
-    #alignmentButtons = {};
-    #rankButtons = {};
-    #bamButton; #boinkButton;
-    #zapButton; #zoinkButton;
-    #flipButton; #stopButton;
-    #aiButton;
-    
-    constructor(scene, chessTiles) {
-        this.#scene = scene;
-        this.#chessTiles = chessTiles;
+	constructor(scene, chessTiles) {
+		this.#scene = scene;
+		this.#chessTiles = chessTiles;
 
-        let dev_x_anchor = (X_ANCHOR - TILE_SIZE) / 2;
-        let dev_y_anchor = (Y_ANCHOR - 0.5 * TILE_SIZE) / 2;
-        
-        const alignments = [PLAYER, COMPUTER];
-        const alignment_names = ["white", "black"];
-        const ranks = [PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING];
-        const rank_names = ["♙", "♖", "♘", "♗", "♕", "♔"];
+		this.#devButton = this.#scene.add.text(0, 0, "Dev Mode", {
+			fill: CREAMHEX,
+			backgroundColor: ONYXHEX,
+		});
+		this.#devButton.on("pointerdown", () => {
+			if (DEV_MODE == true) {
+				prev_bamzap = dev_bamzap;
+				prev_stopOn = dev_stopOn;
+				prev_deadAI = dev_deadAI;
+				dev_bamzap = dev_stopOn = dev_deadAI = false;
+			} else {
+				dev_bamzap = prev_bamzap;
+				dev_stopOn = prev_stopOn;
+				dev_deadAI = prev_deadAI;
+			}
+			toggleDev();
+			for (let button of this.getNondevButtons()) button.visible = !button.visible;
+		});
 
-        this.#devButton = this.#scene.add.text(dev_x_anchor, dev_y_anchor, "Dev Mode", {
-            fill: CREAMHEX,
-            backgroundColor: ONYXHEX,
-            padding: { left: 20, right: 20, top: 10, bottom: 10 },
-        });
-        this.#devButton.on("pointerdown", () => {
-            if (DEV_MODE == true) {
-                prev_bamzap = dev_bamzap;
-                prev_stopOn = dev_stopOn;
-                prev_deadAI = dev_deadAI;
-                dev_bamzap = dev_stopOn = dev_deadAI = false;
-            } else {
-                dev_bamzap = prev_bamzap;
-                dev_stopOn = prev_stopOn;
-                dev_deadAI = prev_deadAI;
-            }
-            toggleDev();
-            for (let button of this.getNondevButtons())
-                button.visible = !button.visible;
-        });
+		for (let i = 0; i < alignments.length; i++) {
+			this.#alignmentButtons[alignments[i]] = this.#scene.add.text(0, 0, alignment_names[i], STYLE_OFF);
+			this.#alignmentButtons[alignments[i]].on("pointerdown", () => {
+				if (dev_alignment != alignments[i]) {
+					this.toggleButton(this.#alignmentButtons[dev_alignment]);
+					dev_setAlignment(alignments[i]);
+					this.toggleButton(this.#alignmentButtons[alignments[i]]);
+				}
+			});
+		}
 
-        for (let i = 0; i < alignments.length; i++) {
-            this.#alignmentButtons[alignments[i]] = this.#scene.add.text((0.5 + i) * dev_x_anchor, 2.5 * dev_y_anchor, alignment_names[i], STYLE_OFF);
-            this.#alignmentButtons[alignments[i]].on("pointerdown", () => {
-                if (dev_alignment != alignments[i]) {
-                    this.toggleButton(this.#alignmentButtons[dev_alignment]);
-                    dev_setAlignment(alignments[i]);
-                    this.toggleButton(this.#alignmentButtons[alignments[i]]);
-                }
-            })
-        };
+		for (let i = 0; i < ranks.length; i++) {
+			this.#rankButtons[ranks[i]] = this.#scene.add.text(0, 0, rank_names[i], STYLE_OFF);
+			this.#rankButtons[ranks[i]].on("pointerdown", () => {
+				if (dev_rank != ranks[i]) {
+					this.toggleButton(this.#rankButtons[dev_rank]);
+					dev_setRank(ranks[i]);
+					this.toggleButton(this.#rankButtons[ranks[i]]);
+				}
+			});
+		}
 
-        for (let i = 0; i < ranks.length; i++) {
-            this.#rankButtons[ranks[i]] = this.#scene.add.text(((1 + 2 * i) / 6) * dev_x_anchor, 3.5 * dev_y_anchor, rank_names[i], STYLE_OFF);
-            this.#rankButtons[ranks[i]].on("pointerdown", () => {
-                if (dev_rank != ranks[i]) {
-                    this.toggleButton(this.#rankButtons[dev_rank]);
-                    dev_setRank(ranks[i]);
-                    this.toggleButton(this.#rankButtons[ranks[i]]);
-                }
-            })
-        };
+		this.#bamButton = this.#scene.add.text(0, 0, "bam", STYLE_OFF);
+		this.#zapButton = this.#scene.add.text(0, 0, "zap", STYLE_OFF);
+		this.#boinkButton = this.#scene.add.text(0, 0, "boink", STYLE_OFF);
+		this.#zoinkButton = this.#scene.add.text(0, 0, "zoink", STYLE_OFF);
 
-        this.#bamButton = this.#scene.add.text(0.5 * dev_x_anchor, 4.5 * dev_y_anchor, "bam", STYLE_OFF);
-        this.#zapButton = this.#scene.add.text(1.5 * dev_x_anchor, 4.5 * dev_y_anchor, "zap", STYLE_OFF);
-        this.#boinkButton = this.#scene.add.text(0.5 * dev_x_anchor, 5.5 * dev_y_anchor, "boink", STYLE_OFF);
-        this.#zoinkButton = this.#scene.add.text(1.5 * dev_x_anchor, 5.5 * dev_y_anchor, "zoink", STYLE_OFF);
+		this.#bamButton.on("pointerdown", () => {
+			if (dev_bamzap == ZAP) this.toggleButton(this.#zapButton);
+			dev_toggleFeature(BAM);
+			this.toggleButton(this.#bamButton);
+		});
+		this.#zapButton.on("pointerdown", () => {
+			if (dev_bamzap == BAM) this.toggleButton(this.#bamButton);
+			dev_toggleFeature(ZAP);
+			this.toggleButton(this.#zapButton);
+		});
+		this.#boinkButton.on("pointerdown", () => {
+			this.#chessTiles.unselect();
+			this.#chessTiles.boardState.initializePieces(dev_alignment, true);
+		});
+		this.#zoinkButton.on("pointerdown", () => {
+			this.#chessTiles.unselect();
+			this.#chessTiles.boardState.zapPieces(dev_alignment);
+		});
 
-        this.#bamButton.on("pointerdown", () => {
-            if (dev_bamzap == ZAP)
-                this.toggleButton(this.#zapButton);
-            dev_toggleFeature(BAM);
-            this.toggleButton(this.#bamButton);
-        });
-        this.#zapButton.on("pointerdown", () => {
-            if (dev_bamzap == BAM)
-                this.toggleButton(this.#bamButton);
-            dev_toggleFeature(ZAP);
-            this.toggleButton(this.#zapButton);
-        });
-        this.#boinkButton.on("pointerdown", () => {
-            this.#chessTiles.unselect();
-            this.#chessTiles.boardState.initializePieces(dev_alignment, true);
-        });
-        this.#zoinkButton.on("pointerdown", () => {
-            this.#chessTiles.unselect();
-            this.#chessTiles.boardState.zapPieces(dev_alignment);
-        });
+		this.#flipButton = this.#scene.add.text(0, 0, "Flip!", STYLE_OFF);
+		this.#stopButton = this.#scene.add.text(0, 0, "Stop!", STYLE_OFF);
 
-        this.#flipButton = this.#scene.add.text(0.5 * dev_x_anchor, 7.5 * dev_y_anchor, "Flip!", STYLE_OFF);
-        this.#stopButton = this.#scene.add.text(1.5 * dev_x_anchor, 7.5 * dev_y_anchor, "Stop!", STYLE_OFF);
+		this.#flipButton.on("pointerdown", () => {
+			this.#chessTiles.unselect();
+			this.#chessTiles.toggleTurn(true);
+		});
+		this.#stopButton.on("pointerdown", () => {
+			dev_toggleFeature(STOP);
+			this.toggleButton(this.#stopButton);
+		});
 
-        this.#flipButton.on("pointerdown", () => {
-            this.#chessTiles.unselect();
-            this.#chessTiles.toggleTurn(true);
-        });
-        this.#stopButton.on("pointerdown", () => {
-            dev_toggleFeature(STOP);
-            this.toggleButton(this.#stopButton);
-        });
+		this.#aiButton = this.#scene.add.text(0, 0, "Disable AI", STYLE_OFF);
 
-        this.#aiButton = this.#scene.add.text(1.0 * dev_x_anchor, 9.5 * dev_y_anchor, "Disable AI", STYLE_OFF)
+		this.#aiButton.on("pointerdown", () => {
+			dev_toggleAI();
+			if (dev_deadAI) this.#aiButton.setText("Enable AI");
+			else this.#aiButton.setText("Disable AI");
+		});
 
-        this.#aiButton.on("pointerdown", () => {
-            dev_toggleAI();
-            if (dev_deadAI)
-                this.#aiButton.setText("Enable AI");
-            else
-                this.#aiButton.setText("Disable AI");
-        });
+		configureButtons(this.#devButton, ...this.getNondevButtons());
 
-        this.configureButton(this.#devButton, ...this.getNondevButtons());
+		// Restore dev mode settings
+		let toggled_buttons = [];
+		if (!DEV_MODE) for (let button of this.getNondevButtons()) button.visible = !button.visible;
+		if (dev_alignment) toggled_buttons.push(this.#alignmentButtons[dev_alignment]);
+		if (dev_rank) toggled_buttons.push(this.#rankButtons[dev_rank]);
+		if (DEV_MODE ? dev_bamzap == ZAP : prev_bamzap == ZAP) toggled_buttons.push(this.#zapButton);
+		if (DEV_MODE ? dev_bamzap == BAM : prev_bamzap == BAM) toggled_buttons.push(this.#bamButton);
+		if (DEV_MODE ? dev_stopOn : prev_stopOn) toggled_buttons.push(this.#stopButton);
+		if (DEV_MODE ? dev_deadAI : prev_deadAI) this.#aiButton.setText("Enable AI");
+		this.toggleButton(...toggled_buttons);
+	}
 
-        // Restore dev mode settings
-        let toggled_buttons = [];
-        if (!DEV_MODE)
-            for (let button of this.getNondevButtons())
-                button.visible = !button.visible;
-        if (dev_alignment)
-            toggled_buttons.push(this.#alignmentButtons[dev_alignment]);
-        if (dev_rank)
-            toggled_buttons.push(this.#rankButtons[dev_rank]);
-        if (DEV_MODE ? dev_bamzap == ZAP : prev_bamzap == ZAP)
-            toggled_buttons.push(this.#zapButton);
-        if (DEV_MODE ? dev_bamzap == BAM : prev_bamzap == BAM)
-            toggled_buttons.push(this.#bamButton);
-        if (DEV_MODE ? dev_stopOn : prev_stopOn)
-            toggled_buttons.push(this.#stopButton);
-        if (DEV_MODE ? dev_deadAI : prev_deadAI)
-            this.#aiButton.setText("Enable AI");
-        this.toggleButton(...toggled_buttons);
-    }
+	resize() {
+		this.#devButton.setPosition(LEFT_X_CENTER, LEFT_UNIT);
+		for (let i = 0; i < alignments.length; i++)
+			this.#alignmentButtons[alignments[i]].setPosition((0.5 + i) * LEFT_X_CENTER, 2.5 * LEFT_UNIT);
+		for (let i = 0; i < ranks.length; i++)
+			this.#rankButtons[ranks[i]].setPosition(((1 + 2 * i) / 6) * LEFT_X_CENTER, 3.5 * LEFT_UNIT);
+		this.#bamButton.setPosition(0.5 * LEFT_X_CENTER, 4.5 * LEFT_UNIT);
+		this.#zapButton.setPosition(1.5 * LEFT_X_CENTER, 4.5 * LEFT_UNIT);
+		this.#boinkButton.setPosition(0.5 * LEFT_X_CENTER, 5.5 * LEFT_UNIT);
+		this.#zoinkButton.setPosition(1.5 * LEFT_X_CENTER, 5.5 * LEFT_UNIT);
+		this.#flipButton.setPosition(0.5 * LEFT_X_CENTER, 7.5 * LEFT_UNIT);
+		this.#stopButton.setPosition(1.5 * LEFT_X_CENTER, 7.5 * LEFT_UNIT);
+		this.#aiButton.setPosition(1.0 * LEFT_X_CENTER, 9.5 * LEFT_UNIT);
 
-    // Return list of all dev buttons excluding the dev mode button
-    getNondevButtons() {
-        return [...Object.values(this.#alignmentButtons), 
-                ...Object.values(this.#rankButtons), 
-                this.#bamButton, this.#boinkButton, 
-                this.#zapButton, this.#zoinkButton, 
-                this.#flipButton, this.#stopButton, 
-                this.#aiButton,];
-    }
-    
-    // Configure default behaviors for all dev buttons
-    configureButton(...buttons) {
-        for (let button of buttons)
-            button
-                .setInteractive()
-                .setOrigin(0.5)
-                .on("pointerover", () => { button.setScale(1.2) }) // Increase the scale (grow the button by 20%)
-                
-                .on("pointerout", () => { button.setScale(1) }); // Reset to original size
-    }
+		paddingTexts(LEFT_UNIT / 12, LEFT_UNIT / 12, this.#devButton, ...this.getNondevButtons());
+		fontsizeTexts((LEFT_UNIT / 12) * 9, this.#devButton, ...this.getNondevButtons());
+	}
 
-    // Toggle visual on/off of dev buttons (does not change actual dev settings)
-    toggleButton(...buttons) {
-        for (let button of buttons)
-            if (button.style.color == CREAMHEX)
-                button.setStyle(STYLE_ON);
-            else
-                button.setStyle(STYLE_OFF);
-    }
+	// Return list of all dev buttons excluding the dev mode button
+	getNondevButtons() {
+		return [
+			...Object.values(this.#alignmentButtons),
+			...Object.values(this.#rankButtons),
+			this.#bamButton,
+			this.#boinkButton,
+			this.#zapButton,
+			this.#zoinkButton,
+			this.#flipButton,
+			this.#stopButton,
+			this.#aiButton,
+		];
+	}
+
+	// Toggle visual on/off of dev buttons (does not change actual dev settings)
+	toggleButton(...buttons) {
+		for (let button of buttons)
+			if (button.style.color == CREAMHEX) button.setStyle(STYLE_ON);
+			else button.setStyle(STYLE_OFF);
+	}
 }
 
 export {dev_alignment, dev_rank, dev_bamzap, dev_stopOn, dev_deadAI};

--- a/src/game-objects/pieces-taken.js
+++ b/src/game-objects/pieces-taken.js
@@ -1,11 +1,9 @@
-// local constants for my "captured pieces" container
-const TILE_SIZE = 52; // width & height of each tile
-const X_ANCHOR = 1072 - 3.5 * TILE_SIZE; // x pixel of leftmost tile
-const Y_ANCHOR = 300 - 3.5 * TILE_SIZE; // y pixel of topmost tile for captured table
-import {WHITE_TILE_COLOR, BLACK_TILE_COLOR} from "./constants";
+import {WHITE_TILE_COLOR, BLACK_TILE_COLOR, fontsizeTexts} from "./constants";
 import {PAWN, ROOK, KNIGHT, BISHOP, QUEEN, START_TEXT_ONE} from "./constants";
 import {PLAYER, COMPUTER} from "./constants";
 import {ChessPiece} from "./chess-piece";
+
+import {RIGHT_X_CENTER, RIGHT_UNIT} from "./constants";
 
 export class PiecesTaken {
 	preload() {
@@ -28,191 +26,82 @@ export class PiecesTaken {
 	}
 
 	scene;
-	piecesTaken;
 
-	wPawnScore;
-	bPawnScore;
-	wRookScore;
-	bRookScore;
-	wKnightScore;
-	bKnightScore;
-	wBishopScore;
-	bBishopScore;
-	wQueenScore;
-	bQueenScore;
+	titleText;
+	box1;
+	box2;
 
-	wPawnScores;
-	bPawnScores;
-	wRookScores;
-	bRookScores;
-	wKnightScores;
-	bKnightScores;
-	wBishopScores;
-	bBishopScores;
-	wQueenScores;
-	bQueenScores;
+	scores;
+	texts;
+	images;
 
 	constructor(scene) {
 		// set up variables to keep track of elements
 		this.scene = scene;
-		this.piecesTaken = [];
-
-		this.wPawnScore = 0;
-		this.bPawnScore = 0;
-		this.wRookScore = 0;
-		this.bRookScore = 0;
-		this.wKnightScore = 0;
-		this.bKnightScore = 0;
-		this.wBishopScore = 0;
-		this.bBishopScore = 0;
-		this.wQueenScore = 0;
-		this.bQueenScore = 0;
 
 		// add the title and the two "boxes" for the pieces
-		this.scene.add.text(910, 26, "Captured Pieces:", {
+		this.titleText = this.scene.add.text(0, 0, "Captured Pieces", {
 			fontFamily: "'Pixelify Sans', sans-serif",
-			fontSize: 34,
 			color: START_TEXT_ONE,
 		});
-		this.scene.add.rectangle(1050, 144, 7.25 * TILE_SIZE, 2.5 * TILE_SIZE, WHITE_TILE_COLOR);
-		this.scene.add.rectangle(1050, 144, 7 * TILE_SIZE, 2.25 * TILE_SIZE, BLACK_TILE_COLOR);
-		// Set up captured pieces table
-		for (let i = 0; i < 5; i++) {
-			this.piecesTaken.push([]);
+		this.box1 = this.scene.add.rectangle(0, 0, 0, 0, WHITE_TILE_COLOR).setOrigin(0.5);
+		this.box2 = this.scene.add.rectangle(0, 0, 0, 0, BLACK_TILE_COLOR).setOrigin(0.5);
+
+		this.scores = {};
+		this.texts = {};
+		this.images = {};
+		for (const alignment of [PLAYER, COMPUTER]) {
+			this.scores[alignment] = {};
+			this.texts[alignment] = {};
+			this.images[alignment] = {};
+			for (const rank of [PAWN, ROOK, KNIGHT, BISHOP, QUEEN]) {
+				this.scores[alignment][rank] = 0;
+
+				this.texts[alignment][rank] = this.scene.add
+					.text(0, 0, "00", {
+						color: START_TEXT_ONE,
+					})
+					.setOrigin(0.5);
+
+				this.images[alignment][rank] = new ChessPiece(this.scene, 0, 0, rank, alignment).setOrigin(0.5);
+				this.scene.add.existing(this.images[alignment][rank]);
+			}
 		}
 
-		var j = 0;
-		this.addPiece(0, j, PAWN, COMPUTER);
-		this.addPiece(1, j, ROOK, COMPUTER);
-		this.addPiece(2, j, KNIGHT, COMPUTER);
-		this.addPiece(3, j, BISHOP, COMPUTER);
-		this.addPiece(4, j, QUEEN, COMPUTER);
-
-		j = 1;
-		this.addPiece(0, j, PAWN, PLAYER);
-		this.addPiece(1, j, ROOK, PLAYER);
-		this.addPiece(2, j, KNIGHT, PLAYER);
-		this.addPiece(3, j, BISHOP, PLAYER);
-		this.addPiece(4, j, QUEEN, PLAYER);
-
-		// add in score keeping
-		this.scene.bPawnScores = this.scene.add.text(X_ANCHOR + 26, Y_ANCHOR - 10, "0", {
-			fontSize: 22,
-			color: START_TEXT_ONE,
-		});
-		this.scene.bRookScores = this.scene.add.text(X_ANCHOR + 26 + 72, Y_ANCHOR - 10, "0", {
-			fontSize: 22,
-			color: START_TEXT_ONE,
-		});
-		this.scene.bKnightScores = this.scene.add.text(X_ANCHOR + 26 + 2 * 72, Y_ANCHOR - 10, "0", {
-			fontSize: 22,
-			color: START_TEXT_ONE,
-		});
-		this.scene.bBishopScores = this.scene.add.text(X_ANCHOR + 26 + 3 * 72, Y_ANCHOR - 10, "0", {
-			fontSize: 22,
-			color: START_TEXT_ONE,
-		});
-		this.scene.bQueenScores = this.scene.add.text(X_ANCHOR + 26 + 4 * 72, Y_ANCHOR - 10, "0", {
-			fontSize: 22,
-			color: START_TEXT_ONE,
-		});
-		this.scene.wPawnScores = this.scene.add.text(X_ANCHOR + 26, Y_ANCHOR - 10 + TILE_SIZE, "0", {
-			fontSize: 22,
-			color: START_TEXT_ONE,
-		});
-		this.scene.wRookScores = this.scene.add.text(X_ANCHOR + 26 + 72, Y_ANCHOR - 10 + TILE_SIZE, "0", {
-			fontSize: 22,
-			color: START_TEXT_ONE,
-		});
-		this.scene.wKnightScores = this.scene.add.text(X_ANCHOR + 26 + 2 * 72, Y_ANCHOR - 10 + TILE_SIZE, "0", {
-			fontSize: 22,
-			color: START_TEXT_ONE,
-		});
-		this.scene.wBishopScores = this.scene.add.text(X_ANCHOR + 26 + 3 * 72, Y_ANCHOR - 10 + TILE_SIZE, "0", {
-			fontSize: 22,
-			color: START_TEXT_ONE,
-		});
-		this.scene.wQueenScores = this.scene.add.text(X_ANCHOR + 26 + 4 * 72, Y_ANCHOR - 10 + TILE_SIZE, "0", {
-			fontSize: 22,
-			color: START_TEXT_ONE,
-		});
+		this.resize();
 	}
 
-	addPiece(i, j, rank, alignment) {
-		this.piecesTaken[i][j] = new ChessPiece(this.scene, X_ANCHOR + i * 72, Y_ANCHOR + j * TILE_SIZE, rank, alignment);
-		this.scene.add.existing(this.piecesTaken[i][j]);
-		this.scene.add.text(X_ANCHOR + 15 + i * 72, Y_ANCHOR - 7 + j * TILE_SIZE, "x ", {
-			fontFamily: "'Pixelify Sans', sans-serif",
-			fontSize: 16,
-			color: START_TEXT_ONE,
-		});
+	resize() {
+		this.titleText.setPosition(RIGHT_X_CENTER, 0.5 * RIGHT_UNIT).setOrigin(0.5);
+		fontsizeTexts(RIGHT_UNIT / 2, this.titleText);
+
+		this.box1.setPosition(RIGHT_X_CENTER, 2.5 * RIGHT_UNIT);
+		this.box2.setPosition(RIGHT_X_CENTER, 2.5 * RIGHT_UNIT);
+		this.box1.setSize(5.75 * RIGHT_UNIT, 2.75 * RIGHT_UNIT);
+		this.box2.setSize(5.5 * RIGHT_UNIT, 2.5 * RIGHT_UNIT);
+
+		let x, y, counter;
+		for (const alignment of [PLAYER, COMPUTER]) {
+			y = 2.5 * RIGHT_UNIT;
+			y += alignment == PLAYER ? (2.5 / 4) * RIGHT_UNIT : (-2.5 / 4) * RIGHT_UNIT;
+			counter = -2;
+			for (const rank of [PAWN, ROOK, KNIGHT, BISHOP, QUEEN]) {
+				x = RIGHT_X_CENTER + (1.1 * counter + 0.25) * RIGHT_UNIT;
+				this.texts[alignment][rank].setPosition(x, y);
+				x = RIGHT_X_CENTER + (1.1 * counter - 0.25) * RIGHT_UNIT;
+				this.images[alignment][rank].setPosition(x, y);
+
+				fontsizeTexts(RIGHT_UNIT / 3, this.texts[alignment][rank]);
+				this.images[alignment][rank].scale = RIGHT_UNIT / 60;
+
+				counter += 1;
+			}
+		}
 	}
 
 	takePiece(rank, alignment) {
-		var t = "error";
-		// determine which count to update from based on rank and alignment
-		if (alignment == PLAYER) {
-			if (rank == PAWN) {
-				this.scene.wPawnScore = this.wPawnScore + 1;
-				t = this.scene.wPawnScore.toString();
-				this.scene.wPawnScores.text = t;
-				this.wPawnScore = this.wPawnScore + 1;
-			}
-			if (rank == KNIGHT) {
-				this.scene.wKnightScore = this.wKnightScore + 1;
-				t = this.scene.wKnightScore.toString();
-				this.scene.wKnightScores.text = t;
-				this.wKnightScore = this.wKnightScore + 1;
-			}
-			if (rank == ROOK) {
-				this.scene.wRookScore = this.wRookScore + 1;
-				t = this.scene.wRookScore.toString();
-				this.scene.wRookScores.text = t;
-				this.wRookScore = this.wRookScore + 1;
-			}
-			if (rank == BISHOP) {
-				this.scene.wBishopScore = this.wBishopScore + 1;
-				t = this.scene.wBishopScore.toString();
-				this.scene.wBishopScores.text = t;
-				this.wBishopScore = this.wBishopScore + 1;
-			}
-			if (rank == QUEEN) {
-				this.scene.wQueenScore = this.wQueenScore + 1;
-				t = this.scene.wQueenScore.toString();
-				this.scene.wQueenScores.text = t;
-				this.wQueenScore = this.wQueenScore + 1;
-			}
-		} else if (alignment == COMPUTER) {
-			if (rank == PAWN) {
-				this.scene.bPawnScore = this.bPawnScore + 1;
-				t = this.scene.bPawnScore.toString();
-				this.scene.bPawnScores.text = t;
-				this.bPawnScore = this.bPawnScore + 1;
-			}
-			if (rank == KNIGHT) {
-				this.scene.bKnightScore = this.bKnightScore + 1;
-				t = this.scene.bKnightScore.toString();
-				this.scene.bKnightScores.text = t;
-				this.bKnightScore = this.bKnightScore + 1;
-			}
-			if (rank == ROOK) {
-				this.scene.bRookScore = this.bRookScore + 1;
-				t = this.scene.bRookScore.toString();
-				this.scene.bRookScores.text = t;
-				this.bRookScore = this.bRookScore + 1;
-			}
-			if (rank == BISHOP) {
-				this.scene.bBishopScore = this.bBishopScore + 1;
-				t = this.scene.bBishopScore.toString();
-				this.scene.bBishopScores.text = t;
-				this.bBishopScore = this.bBishopScore + 1;
-			}
-			if (rank == QUEEN) {
-				this.scene.bQueenScore = this.bQueenScore + 1;
-				t = this.scene.bQueenScore.toString();
-				this.scene.bQueenScores.text = t;
-				this.bQueenScore = this.bQueenScore + 1;
-			}
-		}
+		this.scores[alignment][rank] += 1;
+		let text = this.scores[alignment][rank].toString().padStart(2, "0");
+		this.texts[alignment][rank].text = text;
 	}
 }

--- a/src/game-objects/test/chessboard.test.js
+++ b/src/game-objects/test/chessboard.test.js
@@ -49,6 +49,10 @@ class MockChessPiece {
 		return this.coordinate;
 	}
 
+	setOrigin() {
+		return this;
+	}
+
 	destroy() {}
 }
 jest.mock("../chess-piece", () => {
@@ -110,7 +114,16 @@ describe("", () => {
 			this.fillColor = color;
 		}
 
+		setOrigin() {
+			return this;
+		}
 		setInteractive() {
+			return this;
+		}
+		setPosition() {
+			return this;
+		}
+		setSize() {
 			return this;
 		}
 		on() {
@@ -136,7 +149,13 @@ describe("", () => {
 		setInteractive() {
 			return this;
 		}
+		setPosition() {
+			return this;
+		}
 		on() {
+			return this;
+		}
+		setFontSize() {
 			return this;
 		}
 

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -6,6 +6,10 @@ import {RulesButton} from "./RulesButton";
 
 import {ChessTiles} from "../../game-objects/chess-tiles";
 
+import {RIGHT_X_CENTER} from "../../game-objects/constants";
+import {DOZEN_HEIGHT, UNIT_HEIGHT} from "../../game-objects/constants";
+import {configureButtons, paddingTexts, fontsizeTexts} from "../../game-objects/constants";
+
 import {
 	PAWN,
 	ROOK,
@@ -21,6 +25,11 @@ import {
 } from "../../game-objects/constants";
 
 export class Game extends Scene {
+	endButton;
+	settingsButton;
+	rulesButton;
+	chessTiles;
+
 	constructor() {
 		super("MainGame");
 	}
@@ -80,21 +89,15 @@ export class Game extends Scene {
 
 		this.cameras.main.setBackgroundColor(BACKGROUND_COLOR);
 
-		// and a board, and an icon, and a black tile, and a white tile; Totaling to 40 images
-		new ChessTiles(this);
+		// Add Chessboard & Chess Piece Images
+		this.chessTiles = new ChessTiles(this);
 
-		const endButton = this.add.text(100, 100, "End Game!", {
+		this.endButton = this.add.text(0, 0, "End Game!", {
 			fill: CREAMHEX,
 			backgroundColor: ONYXHEX,
 			fontFamily: "'Pixelify Sans', sans-serif",
-			fontSize: 20,
-			padding: {left: 20, right: 20, top: 10, bottom: 10},
 		});
-		endButton.setPosition(1050, 700);
-		endButton.setInteractive();
-		endButton.setOrigin(0.5);
-
-		endButton.on(
+		this.endButton.on(
 			"pointerdown",
 			function () {
 				import("./GameOver") //
@@ -114,61 +117,40 @@ export class Game extends Scene {
 			this
 		);
 
-		// When the pointer hovers over the button, scale it up
-		endButton.on("pointerover", () => {
-			endButton.setScale(1.2); // Increase the scale (grow the button by 20%)
-		});
-
-		// When the pointer moves away from the button, reset the scale to normal
-		endButton.on("pointerout", () => {
-			endButton.setScale(1); // Reset to original size
-		});
-
-		const settingsButton = this.add.text(100, 100, "See Settings", {
+		this.settingsButton = this.add.text(0, 0, "Settings", {
 			fill: CREAMHEX,
 			backgroundColor: ONYXHEX,
 			fontFamily: "'Pixelify Sans', sans-serif",
-			fontSize: 20,
-			padding: {left: 20, right: 20, top: 10, bottom: 10},
 		});
+		this.settingsButton.on("pointerdown", new SettingsButton(this).click, this);
 
-		const rulesButton = this.add.text(100, 100, "See Rules", {
+		this.rulesButton = this.add.text(0, 0, "Rules", {
 			fill: CREAMHEX,
 			backgroundColor: ONYXHEX,
 			fontFamily: "'Pixelify Sans', sans-serif",
-			fontSize: 20,
-			padding: {left: 20, right: 20, top: 10, bottom: 10},
 		});
+		this.rulesButton.on("pointerdown", new RulesButton(this).click, this);
 
-		settingsButton.setPosition(1050, 600);
-		settingsButton.setInteractive();
-		settingsButton.setOrigin(0.5);
-		settingsButton.on("pointerdown", new SettingsButton(this).click, this);
-		// When the pointer hovers over the button, scale it up
-		settingsButton.on("pointerover", () => {
-			settingsButton.setScale(1.2); // Increase the scale (grow the button by 20%)
-		});
-		// When the pointer moves away from the button, reset the scale to normal
-		settingsButton.on("pointerout", () => {
-			settingsButton.setScale(1); // Reset to original size
-		});
+		const scene = this;
+		configureButtons(this.endButton, this.settingsButton, this.rulesButton);
+		window.addEventListener(
+			"resize",
+			function (event) {
+				scene.resize();
+			},
+			false
+		);
 
-		rulesButton.setPosition(1050, 650);
-
-		rulesButton.setInteractive();
-		rulesButton.setOrigin(0.5);
-		rulesButton.on("pointerdown", new RulesButton(this).click, this);
-
-		// When the pointer hovers over the button, scale it up
-		rulesButton.on("pointerover", () => {
-			rulesButton.setScale(1.2); // Increase the scale (grow the button by 20%)
-		});
-
-		// When the pointer moves away from the button, reset the scale to normal
-		rulesButton.on("pointerout", () => {
-			rulesButton.setScale(1); // Reset to original size
-		});
-
+		this.resize();
 		EventBus.emit("current-scene-ready", this);
+	}
+
+	resize() {
+		this.settingsButton.setPosition(RIGHT_X_CENTER, 9 * DOZEN_HEIGHT);
+		this.rulesButton.setPosition(RIGHT_X_CENTER, 10 * DOZEN_HEIGHT);
+		this.endButton.setPosition(RIGHT_X_CENTER, 11 * DOZEN_HEIGHT);
+		fontsizeTexts(6 * UNIT_HEIGHT, this.endButton, this.settingsButton, this.rulesButton);
+		paddingTexts(4 * UNIT_HEIGHT, 2 * UNIT_HEIGHT, this.endButton, this.settingsButton, this.rulesButton);
+		this.chessTiles.resize();
 	}
 }

--- a/src/game/scenes/GameOver.js
+++ b/src/game/scenes/GameOver.js
@@ -8,7 +8,26 @@ import {
 } from "../../game-objects/constants";
 import {globalMoves, globalPieces, globalWaves} from "../../game-objects/global-stats";
 
+import {paddingTexts, fontsizeTexts} from "../../game-objects/constants";
+import {
+	WINDOW_WIDTH,
+	WINDOW_HEIGHT,
+	CENTER_WIDTH,
+	CENTER_HEIGHT,
+	DOZEN_WIDTH,
+	DOZEN_HEIGHT,
+	UNIT_HEIGHT,
+} from "../../game-objects/constants";
+
 export class GameOver extends Scene {
+	bg;
+	square;
+	titleText;
+	wordsText;
+	numbersText;
+	restartButton;
+	menuButton;
+
 	constructor() {
 		super({key: "GameOver"}); // Scene identifier
 	}
@@ -16,8 +35,6 @@ export class GameOver extends Scene {
 	preload() {
 		this.load.audio("endMusic", "../assets/music/SurvivalChess-End.mp3");
 		this.load.setPath("assets");
-		this.load.image("star", "star.png");
-		this.load.image("background", "bg.png");
 
 		// Load the pixel font
 		WebFont.load({
@@ -45,123 +62,54 @@ export class GameOver extends Scene {
 		// put GAMEOVER over game screen
 		this.scene.moveAbove("MainGame", "GameOver");
 		// Creates an invisible background that also blocks input on the scene underneath
-		const bg = this.add.rectangle(625, 384, 1250, 768, GAMEOVER_BACKGROUND_COLOR, 0);
-		bg.setDepth(50);
+		this.bg = this.add.rectangle(1, 1, 1, 1, GAMEOVER_BACKGROUND_COLOR, 0);
+		this.bg.setDepth(50);
 
 		// Creates a visual background that also blocks input on the scene underneath
-		const square = this.add.rectangle(
-			625,
-			375,
-			800,
-			600,
+		this.square = this.add.rectangle(
+			0,
+			0,
+			0,
+			0,
 			GAMEOVER_BACKGROUND_COLOR_TWO,
 			0.95 // Opacity
 		);
-		square.setDepth(50);
+		this.square.setDepth(50);
 
-		// Creates a visual background that also blocks input on the scene underneath
-		const square2 = this.add.rectangle(
-			625,
-			350,
-			450,
-			225,
-			GAMEOVER_BACKGROUND_COLOR,
-			0.9 // Opacity
-		);
-		square2.setDepth(50);
 		// GAMEOVER text
-		this.add
-			.text(625, 175, "Game Over!", {
+		this.titleText = this.add
+			.text(0, 0, "Game Over!", {
 				fontFamily: "'Pixelify Sans', sans-serif",
-				fontSize: 75,
 				color: GAMEOVER_TEXT_TWO,
 				stroke: GAMEOVER_TEXT_ONE,
-				strokeThickness: 5,
 				align: "center",
 			})
 			.setOrigin(0.5)
 			.setDepth(100);
 
-		var textWidth = 185; // Variable to offset numbers
-		this.add
-			.text(625, 275, "Number of Moves Made: ", {
+		this.wordsText = this.add
+			.text(0, 0, "Number of Moves Made: \nNumber of Captured Pieces: \nNumber of Waves Survived: ", {
 				fontFamily: "'Pixelify Sans', sans-serif",
-				fontSize: 25,
 				color: GAMEOVER_TEXT_TWO,
+				backgroundColor: GAMEOVER_TEXT_ONE,
 				stroke: GAMEOVER_TEXT_ONE,
-				strokeThickness: 4,
 				align: "center",
 			})
 			.setOrigin(0.5)
-			.setDepth(100);
-		this.add
-			.text(625 + textWidth, 275, globalMoves + "", {
-				fontSize: 25,
+			.setDepth(100)
+			.setLineSpacing(50);
+
+		this.numbersText = this.add
+			.text(0, 0, globalMoves + "\n" + globalPieces + "\n" + globalWaves, {
 				color: GAMEOVER_TEXT_TWO,
 				stroke: GAMEOVER_TEXT_ONE,
-				strokeThickness: 4,
 				align: "center",
 			})
 			.setOrigin(0.5)
-			.setDepth(100);
+			.setDepth(100)
+			.setLineSpacing(50);
 
-		this.add
-			.text(625, 350, "Number of Captured Pieces: ", {
-				fontFamily: "'Pixelify Sans', sans-serif",
-				fontSize: 25,
-				color: GAMEOVER_TEXT_TWO,
-				stroke: GAMEOVER_TEXT_ONE,
-				strokeThickness: 4,
-				align: "center",
-			})
-			.setOrigin(0.5)
-			.setDepth(100);
-
-		this.add
-			.text(625 + textWidth, 350, globalPieces + "", {
-				fontSize: 25,
-				color: GAMEOVER_TEXT_TWO,
-				stroke: GAMEOVER_TEXT_ONE,
-				strokeThickness: 4,
-				align: "center",
-			})
-			.setOrigin(0.5)
-			.setDepth(100);
-
-		this.add
-			.text(625, 425, "Number of Waves Survived: ", {
-				fontFamily: "'Pixelify Sans', sans-serif",
-				fontSize: 25,
-				color: GAMEOVER_TEXT_TWO,
-				stroke: GAMEOVER_TEXT_ONE,
-				strokeThickness: 4,
-				align: "center",
-			})
-			.setOrigin(0.5)
-			.setDepth(100);
-
-		this.add
-			.text(625 + textWidth, 425, globalWaves + "", {
-				fontSize: 25,
-				color: GAMEOVER_TEXT_TWO,
-				stroke: GAMEOVER_TEXT_ONE,
-				strokeThickness: 4,
-				align: "center",
-			})
-			.setOrigin(0.5)
-			.setDepth(100);
-
-		this.createButton(625, 600, "Restart Game", () => {
-			console.log("Restarting game...");
-			// Stop background music
-			this.endMusic.stop();
-			this.endMusicPlaying = false;
-			this.scene.stop("GameOver");
-			this.scene.stop("MainGame"); // Reset game state
-			this.scene.start("MainGame");
-		});
-
-		this.createButton(625, 525, "Main Menu", () => {
+		this.menuButton = this.createButton(0, 0, "Main Menu", () => {
 			console.log("Returning to main menu...");
 			// Stop background music
 			this.endMusic.stop();
@@ -171,10 +119,54 @@ export class GameOver extends Scene {
 			this.scene.start("Game"); // can change if needed
 		});
 
-		bg.setInteractive();
-		square.setInteractive();
-		square2.setInteractive();
+		this.restartButton = this.createButton(0, 0, "Restart Game", () => {
+			console.log("Restarting game...");
+			// Stop background music
+			this.endMusic.stop();
+			this.endMusicPlaying = false;
+			this.scene.stop("GameOver");
+			this.scene.stop("MainGame"); // Reset game state
+			this.scene.start("MainGame");
+		});
+
+		this.bg.setInteractive();
+		this.square.setInteractive();
+
+		const scene = this;
+		window.addEventListener(
+			"resize",
+			function (event) {
+				scene.resize();
+			},
+			false
+		);
+
+		this.resize();
 		EventBus.emit("current-scene-ready", this); // notify event system
+	}
+
+	resize() {
+		this.bg.setPosition(CENTER_WIDTH, CENTER_HEIGHT);
+		this.bg.setSize(WINDOW_WIDTH, WINDOW_HEIGHT);
+		this.square.setPosition(CENTER_WIDTH, CENTER_HEIGHT);
+		this.square.setSize(10 * DOZEN_HEIGHT, 10 * DOZEN_HEIGHT);
+		this.titleText.setPosition(CENTER_WIDTH, 2 * DOZEN_HEIGHT);
+		fontsizeTexts(1.5 * DOZEN_HEIGHT, this.titleText);
+
+		this.wordsText.setPosition(6 * DOZEN_WIDTH, 5 * DOZEN_HEIGHT);
+		this.numbersText.setPosition(6 * DOZEN_WIDTH + 3.5 * DOZEN_HEIGHT, 5 * DOZEN_HEIGHT);
+		fontsizeTexts(6 * UNIT_HEIGHT, this.wordsText, this.numbersText);
+		this.wordsText.setPadding(4 * UNIT_HEIGHT, 2.5 * UNIT_HEIGHT, DOZEN_HEIGHT, 2.5 * UNIT_HEIGHT);
+		this.wordsText.setLineSpacing(6 * UNIT_HEIGHT);
+		this.numbersText.setLineSpacing(6 * UNIT_HEIGHT);
+
+		this.menuButton.setPosition(CENTER_WIDTH, 8 * DOZEN_HEIGHT);
+		this.restartButton.setPosition(CENTER_WIDTH, 10 * DOZEN_HEIGHT);
+		paddingTexts(4 * UNIT_HEIGHT, 2 * UNIT_HEIGHT, this.menuButton, this.restartButton);
+		fontsizeTexts(9 * UNIT_HEIGHT, this.menuButton, this.restartButton);
+
+		for (let text of [this.titleText, this.wordsText, this.numbersText, this.restartButton, this.menuButton])
+			text.setStroke(GAMEOVER_TEXT_ONE, UNIT_HEIGHT);
 	}
 
 	createButton(x, y, text, callback) {
@@ -197,5 +189,7 @@ export class GameOver extends Scene {
 		button.on("pointerdown", callback); // Execute the callback on click
 		button.on("pointerover", () => button.setScale(1.1)); // Slightly enlarge on hover
 		button.on("pointerout", () => button.setScale(1)); // Reset scale when not hovered
+
+		return button;
 	}
 }

--- a/src/game/scenes/Promotion.js
+++ b/src/game/scenes/Promotion.js
@@ -1,6 +1,17 @@
 import {Scene} from "phaser";
 import {EventBus} from "../EventBus";
-import {QUEEN, BISHOP, ROOK, KNIGHT, X_ANCHOR, Y_ANCHOR, TILE_SIZE} from "../../game-objects/constants";
+import {QUEEN, BISHOP, ROOK, KNIGHT} from "../../game-objects/constants";
+
+import {fontsizeTexts} from "../../game-objects/constants";
+import {
+	WINDOW_WIDTH,
+	WINDOW_HEIGHT,
+	CENTER_WIDTH,
+	CENTER_HEIGHT,
+	DOZEN_WIDTH,
+	DOZEN_HEIGHT,
+	UNIT_WIDTH,
+} from "../../game-objects/constants";
 
 export class Promotion extends Scene {
 	constructor() {
@@ -16,100 +27,106 @@ export class Promotion extends Scene {
 	}
 
 	create() {
-		const bgX = this.cameras.main.width;
-		const bgY = this.cameras.main.height;
-		this.add
-			.text(500, 490, "Select what piece to promote your pawn into", {
+		this.text = this.add
+			.text(0, 0, "Select what piece to promote your pawn into", {
 				fontFamily: "Arial Black",
-				fontSize: 38,
 				color: "#ffffff",
 				stroke: "#000000",
-				strokeThickness: 8,
 				align: "center",
 			})
 			.setOrigin(0.5)
 			.setDepth(100);
 
-		const queen = this.add
-			.image(X_ANCHOR + 3.5 * TILE_SIZE - 150, Y_ANCHOR + 3.5 * TILE_SIZE, "queen")
-			.setDepth(5)
-			.setScale(1.5);
-		const bishop = this.add
-			.image(X_ANCHOR + 3.5 * TILE_SIZE - 50, Y_ANCHOR + 3.5 * TILE_SIZE, "bishop")
-			.setDepth(5)
-			.setScale(1.5);
-		const knight = this.add
-			.image(X_ANCHOR + 3.5 * TILE_SIZE + 50, Y_ANCHOR + 3.5 * TILE_SIZE, "knight")
-			.setDepth(5)
-			.setScale(1.5);
-		const rook = this.add
-			.image(X_ANCHOR + 3.5 * TILE_SIZE + 150, Y_ANCHOR + 3.5 * TILE_SIZE, "rook")
-			.setDepth(5)
-			.setScale(1.5);
-		const pieces = [queen, bishop, knight, rook];
+		this.queen = this.add.image(0, 0, "queen");
+		this.bishop = this.add.image(0, 0, "bishop");
+		this.knight = this.add.image(0, 0, "knight");
+		this.rook = this.add.image(0, 0, "rook");
+		this.pieces = [this.queen, this.bishop, this.knight, this.rook];
 
-		queen.setInteractive();
-		queen.on(
+		this.queen.on(
 			"pointerdown",
 			function () {
-				// sends event telling promotion is to queen
+				// sends event telling promotion is to this.queen
 				EventBus.emit("PawnPromoted", QUEEN);
 				this.scene.stop("Promotion");
 			},
 			this
 		);
 
-		rook.setInteractive();
-		rook.on(
+		this.rook.on(
 			"pointerdown",
 			function () {
-				// sends event telling promotion is to rook
+				// sends event telling promotion is to this.rook
 				EventBus.emit("PawnPromoted", ROOK);
 				this.scene.stop("Promotion");
 			},
 			this
 		);
 
-		bishop.setInteractive();
-		bishop.on(
+		this.bishop.on(
 			"pointerdown",
 			function () {
-				// sends event telling promotion is to bishop
+				// sends event telling promotion is to this.bishop
 				EventBus.emit("PawnPromoted", BISHOP);
 				this.scene.stop("Promotion");
 			},
 			this
 		);
 
-		knight.setInteractive();
-		knight.on(
+		this.knight.on(
 			"pointerdown",
 			function () {
-				// sends event telling promotion is to knight
+				// sends event telling promotion is to this.knight
 				EventBus.emit("PawnPromoted", KNIGHT);
 				this.scene.stop("Promotion");
 			},
 			this
 		);
 
-		// make pieces larger when moused over to indicate selection
-		for (const piece in pieces) {
+		// make this.pieces larger when moused over to indicate selection
+		for (const piece in this.pieces) {
+			this.pieces[piece].setDepth(5).setScale(1.5).setInteractive();
 			// When the pointer hovers over a piece, scale it up
-			pieces[piece].on("pointerover", () => {
-				pieces[piece].setScale(2);
+			this.pieces[piece].on("pointerover", () => {
+				this.pieces[piece].setScale(UNIT_WIDTH / 4);
 			});
 
 			// When the pointer moves away from the piece, reset the scale to normal
-			pieces[piece].on("pointerout", () => {
-				pieces[piece].setScale(1.5);
+			this.pieces[piece].on("pointerout", () => {
+				this.pieces[piece].setScale(UNIT_WIDTH / 6);
 			});
 		}
 
 		// Creates a visual background that also blocks input on the scene underneath
-		const bg = this.add.rectangle(bgX / 2, bgY / 2, bgX, bgY, 0x3b3b3b, 0.5);
-		bg.setOrigin(0.5);
-		bg.setInteractive();
+		this.bg = this.add.rectangle(1, 1, 1, 1, 0x3b3b3b, 0.5);
+		this.bg.setOrigin(0.5);
+		this.bg.setInteractive();
 
+		const scene = this;
+		window.addEventListener(
+			"resize",
+			function (event) {
+				scene.resize();
+			},
+			false
+		);
+
+		this.resize();
 		EventBus.emit("current-scene-ready", this);
+	}
+
+	resize() {
+		this.bg.setPosition(CENTER_WIDTH, CENTER_HEIGHT);
+		this.bg.setSize(WINDOW_WIDTH, WINDOW_HEIGHT);
+		this.text.setPosition(CENTER_WIDTH, 3 * DOZEN_HEIGHT);
+		this.text.setStroke("#000000", UNIT_WIDTH);
+		fontsizeTexts(4 * UNIT_WIDTH, this.text);
+
+		let counter = 0;
+		for (let piece in this.pieces) {
+			this.pieces[piece].setPosition((4.5 + counter) * DOZEN_WIDTH, CENTER_HEIGHT);
+			this.pieces[piece].scale = UNIT_WIDTH / 6;
+			counter += 1;
+		}
 	}
 }

--- a/src/game/scenes/Rules.js
+++ b/src/game/scenes/Rules.js
@@ -8,15 +8,30 @@ import {
 	RULES_TEXT_THREE,
 } from "../../game-objects/constants";
 
+import {configureButtons, paddingTexts, fontsizeTexts} from "../../game-objects/constants";
+import {
+	WINDOW_WIDTH,
+	WINDOW_HEIGHT,
+	CENTER_WIDTH,
+	CENTER_HEIGHT,
+	DOZEN_WIDTH,
+	DOZEN_HEIGHT,
+	UNIT_HEIGHT,
+} from "../../game-objects/constants";
+
 export class Rules extends Scene {
+	bg;
+	square;
+	titleText;
+	rulesText;
+	closeButton;
+
 	constructor() {
 		super("Rules");
 	}
 
 	preload() {
 		this.load.setPath("assets");
-		this.load.image("star", "star.png");
-		this.load.image("background", "bg.png");
 
 		// Load the pixel font
 		WebFont.load({
@@ -34,114 +49,98 @@ export class Rules extends Scene {
 		// put Rules over game screen
 		this.scene.moveAbove("MainGame", "Rules");
 		// Creates a visual background that also blocks input on the scene underneath
-		const bg = this.add.rectangle(625, 384, 1250, 768, RULES_BACKGROUND_COLOR, 0.5);
-		bg.setDepth(50);
+		this.bg = this.add.rectangle(1, 1, 1, 1, RULES_BACKGROUND_COLOR, 0.5);
+		this.bg.setDepth(50);
 
 		// Creates a visual background that also blocks input on the scene underneath
-		const square = this.add.rectangle(
-			625,
-			384,
-			800,
-			400,
+		this.square = this.add.rectangle(
+			0,
+			0,
+			0,
+			0,
 			RULES_BACKGROUND_COLOR_TWO,
 			0.9 // Opacity
 		);
-		square.setDepth(50);
+		this.square.setDepth(50);
 
 		// Rules text
-		this.add
-			.text(625, 215, "RULES", {
+		this.titleText = this.add
+			.text(0, 0, "RULES", {
 				fontFamily: "'Pixelify Sans', sans-serif",
-				fontSize: 38,
 				color: RULES_TEXT_TWO,
 				stroke: RULES_TEXT_ONE,
-				strokeThickness: 5,
 				align: "center",
 			})
 			.setOrigin(0.5)
 			.setDepth(100);
 
-		this.add
+		this.rulesText = this.add
 			.text(
-				615,
-				400,
+				0,
+				0,
 				"- Pieces move the same as in regular chess\n\n" +
-					"- To move, click on the piece you want to move, and then click on the square\n   you want to move it to\n\n" +
-					"- The enemy pieces spawn in waves that will increase in dificulty in later rounds\n\n" +
-					"- Enemy pieces spawn in the top two rows (rows    &   )\n\n" +
+					"- To move, click on the piece you want to move, and then click on the square you want to move it to\n\n" +
+					"- Enemy pieces spawn in waves that will increase in dificulty in later rounds\n\n" +
+					"- Enemy pieces spawn in the top two rows (rows 7 & 8)\n\n" +
 					"- Your goal is to capture enemy pieces while avoiding checkmate\n\n" +
 					"- The more pieces you capture the more points you will gain\n\n" +
-					"- A new wave of pieces will spawn every        rounds\n\n" +
+					"- A new wave of pieces will spawn every 13 rounds\n\n" +
 					"- Capturing all the enemy pieces will progress you to the next round early",
 				{
 					fontFamily: "'Pixelify Sans', sans-serif",
-					fontSize: 20,
 					color: RULES_TEXT_TWO,
 					stroke: RULES_TEXT_ONE,
-					strokeThickness: 0,
 					align: "left",
 				}
 			)
 			.setOrigin(0.5)
 			.setDepth(100);
 
-		this.add
-			.text(723, 390, "7 8", {
-				fontSize: 20,
-				color: RULES_TEXT_TWO,
-				stroke: RULES_TEXT_ONE,
-				strokeThickness: 0,
-				align: "center",
-			})
-			.setOrigin(0.5)
-			.setDepth(100);
-
-		this.add
-			.text(625, 510, "13", {
-				fontSize: 20,
-				color: RULES_TEXT_TWO,
-				stroke: RULES_TEXT_ONE,
-				strokeThickness: 0,
-				align: "center",
-			})
-			.setOrigin(0.5)
-			.setDepth(100);
-
 		// Button for closing out (this should stay unlike the above)
-		const closeButton = this.add.text(100, 100, "Close Rules", {
+		this.closeButton = this.add.text(0, 0, "Close Rules", {
 			fontFamily: "'Pixelify Sans', sans-serif",
-			fontSize: 25,
 			backgroundColor: RULES_TEXT_THREE,
 			color: RULES_TEXT_TWO,
 			stroke: RULES_TEXT_ONE,
-			strokeThickness: 5,
-			padding: {left: 20, right: 20, top: 10, bottom: 10},
 		});
-		closeButton.setOrigin(0.5);
-		closeButton.setPosition(625, 625);
-		closeButton.setInteractive();
-		closeButton.on(
+		this.closeButton.on(
 			"pointerdown",
 			function () {
 				this.scene.stop("Rules");
 			},
 			this
 		);
-		closeButton.setDepth(100);
+		this.closeButton.setDepth(100);
 
-		// When the pointer hovers over the button, scale it up
-		closeButton.on("pointerover", () => {
-			closeButton.setScale(1.2); // Increase the scale (grow the button by 20%)
-		});
+		this.bg.setInteractive();
+		this.square.setInteractive();
 
-		// When the pointer moves away from the button, reset the scale to normal
-		closeButton.on("pointerout", () => {
-			closeButton.setScale(1); // Reset to original size
-		});
+		const scene = this;
+		configureButtons(this.closeButton);
+		window.addEventListener(
+			"resize",
+			function (event) {
+				scene.resize();
+			},
+			false
+		);
 
-		bg.setInteractive();
-		square.setInteractive();
-
+		this.resize();
 		EventBus.emit("current-scene-ready", this);
+	}
+
+	resize() {
+		this.bg.setPosition(CENTER_WIDTH, CENTER_HEIGHT);
+		this.bg.setSize(WINDOW_WIDTH, WINDOW_HEIGHT);
+		this.square.setPosition(CENTER_WIDTH, 5.5 * DOZEN_HEIGHT);
+		this.square.setSize(10 * DOZEN_WIDTH, 9 * DOZEN_HEIGHT);
+		this.titleText.setPosition(CENTER_WIDTH, 1.75 * DOZEN_HEIGHT);
+		this.rulesText.setPosition(CENTER_WIDTH, 6 * DOZEN_HEIGHT);
+		this.closeButton.setPosition(CENTER_WIDTH, 11 * DOZEN_HEIGHT);
+		this.rulesText.setWordWrapWidth(9.5 * DOZEN_WIDTH);
+		paddingTexts(4 * UNIT_HEIGHT, 2 * UNIT_HEIGHT, this.closeButton);
+		fontsizeTexts(DOZEN_HEIGHT, this.titleText);
+		fontsizeTexts(5 * UNIT_HEIGHT, this.rulesText);
+		fontsizeTexts(9 * UNIT_HEIGHT, this.closeButton);
 	}
 }

--- a/src/game/scenes/Start.js
+++ b/src/game/scenes/Start.js
@@ -115,6 +115,9 @@ export class Start extends Scene {
 					function () {
 						import("./Game") // Dynamically import the Game scene
 							.then((module) => {
+								// Stop background music
+								this.backgroundMusic.stop();
+								this.backgroundMusicPlaying = false;
 								// Only add the scene if it's not already registered
 								if (!this.scene.get("MainGame")) {
 									this.scene.add("MainGame", module.Game); // Add the MainGame scene dynamically

--- a/src/game/scenes/Start.js
+++ b/src/game/scenes/Start.js
@@ -5,7 +5,25 @@ import {RulesButton} from "./RulesButton";
 
 import {START_BACKGROUND_COLOR, START_TEXT_ONE, START_TEXT_TWO} from "../../game-objects/constants";
 
+import {configureButtons, paddingTexts, fontsizeTexts} from "../../game-objects/constants";
+import {resize_constants} from "../../game-objects/constants";
+import {
+	WINDOW_WIDTH,
+	CENTER_WIDTH,
+	DOZEN_WIDTH,
+	DOZEN_HEIGHT,
+	UNIT_WIDTH,
+	UNIT_HEIGHT,
+} from "../../game-objects/constants";
+
 export class Start extends Scene {
+	titleText;
+	introText;
+	creditText;
+	startButton;
+	settingsButton;
+	rulesButton;
+
 	constructor() {
 		super("Game");
 		this.fontLoaded = false;
@@ -13,8 +31,6 @@ export class Start extends Scene {
 
 	preload() {
 		this.load.setPath("assets");
-
-		this.load.image("logo", "logo.png");
 
 		this.load.audio("backgroundMusic", "../assets/music/SurvivalChess-Menu.mp3");
 	}
@@ -50,74 +66,55 @@ export class Start extends Scene {
 
 				this.cameras.main.setBackgroundColor(START_BACKGROUND_COLOR);
 
-				this.add
-					.text(630, 230, "Survival Chess", {
+				this.titleText = this.add
+					.text(0, 0, "Survival Chess", {
 						fontFamily: "'Pixelify Sans', sans-serif",
-						fontSize: 130,
 						color: START_TEXT_ONE,
 						stroke: START_TEXT_TWO,
-						strokeThickness: 8,
 						align: "center",
 					})
-					.setOrigin(0.5)
-					.setDepth(100);
-
-				this.add
+					.setOrigin(0.5);
+				this.introText = this.add
 					.text(
-						630,
-						525,
+						0,
+						0,
 						"Survival Chess is an arcade style chess game. In this game, you play chess against a computer while trying to survive waves of incoming pieces. Capture as many pieces as you can while avoiding checkmate. Good Luck!",
 						{
 							fontFamily: "'Pixelify Sans', sans-serif",
-							fontSize: 20,
 							color: START_TEXT_TWO,
 							backgroundColor: START_TEXT_ONE,
 							stroke: START_TEXT_TWO,
-							strokeThickness: 0,
 							align: "center",
-							padding: 15,
-							fixedWidth: 570,
-							wordWrap: {width: 560}, // Explicitly enable word wrap
+							wordWrap: {width: 4 * DOZEN_WIDTH}, // Explicitly enable word wrap
 						}
 					)
-					.setOrigin(0.5)
-					.setDepth(100);
-				this.add
+					.setOrigin(0.5);
+				this.creditText = this.add
 					.text(
-						625,
-						710,
+						0,
+						0,
 						"Credits: Riana Therrien, Marley Higbee, David Goh, Kaydee Ferrel, Hope Heck, Durva Kadam, Mohamad Tiba, Ritu Ghosh",
 						{
 							fontFamily: "'Pixelify Sans', sans-serif",
-							fontSize: 20,
 							color: START_TEXT_TWO,
 							backgroundColor: START_TEXT_ONE,
 							stroke: START_TEXT_TWO,
-							strokeThickness: 0,
 							align: "center",
-							padding: 10,
-							fixedWidth: 1500,
+							fixedWidth: WINDOW_WIDTH,
 						}
 					)
-					.setOrigin(0.5)
-					.setDepth(100);
-				const startButton = this.add.text(100, 100, "Start Game", {
+					.setOrigin(0.5);
+
+				this.startButton = this.add.text(0, 0, "Start Game", {
 					fontFamily: "'Pixelify Sans', sans-serif",
 					fill: START_TEXT_ONE,
 					backgroundColor: START_TEXT_TWO,
-					padding: {left: 20, right: 20, top: 10, bottom: 10},
 				});
-				startButton.setPosition(550, 370);
-				startButton.setInteractive();
-				startButton.on(
+				this.startButton.on(
 					"pointerdown",
 					function () {
 						import("./Game") // Dynamically import the Game scene
 							.then((module) => {
-								// Stop background music
-								this.backgroundMusic.stop();
-								this.backgroundMusicPlaying = false;
-
 								// Only add the scene if it's not already registered
 								if (!this.scene.get("MainGame")) {
 									this.scene.add("MainGame", module.Game); // Add the MainGame scene dynamically
@@ -129,15 +126,12 @@ export class Start extends Scene {
 					this
 				);
 
-				const settingsButton = this.add.text(100, 100, "Settings", {
+				this.settingsButton = this.add.text(0, 0, "Settings", {
 					fontFamily: "'Pixelify Sans', sans-serif",
 					fill: START_TEXT_ONE,
 					backgroundColor: START_TEXT_TWO,
-					padding: {left: 20, right: 20, top: 10, bottom: 10},
 				});
-				settingsButton.setPosition(1100, 70);
-				settingsButton.setInteractive();
-				settingsButton.on(
+				this.settingsButton.on(
 					"pointerdown",
 					function () {
 						import("./Settings") // Dynamically import the Settings scene
@@ -155,27 +149,52 @@ export class Start extends Scene {
 					this
 				);
 
-				const rulesButton = this.add.text(1100, 600, "Rules", {
+				this.rulesButton = this.add.text(0, 0, "Rules", {
 					fontFamily: "'Pixelify Sans', sans-serif",
 					fill: START_TEXT_ONE,
 					backgroundColor: START_TEXT_TWO,
-					padding: {left: 20, right: 20, top: 10, bottom: 10},
 				});
-				rulesButton.setInteractive();
-				rulesButton.on("pointerdown", new RulesButton(this).click, this);
+				this.rulesButton.on("pointerdown", new RulesButton(this).click, this);
 
-				// When the pointer hovers over the button, scale it up
-				rulesButton.on("pointerover", () => {
-					rulesButton.setScale(1.2); // Increase the scale (grow the button by 20%)
-				});
+				const scene = this;
+				configureButtons(this.startButton, this.settingsButton, this.rulesButton);
+				window.addEventListener(
+					"resize",
+					function (event) {
+						scene.resize();
+					},
+					false
+				);
 
-				// When the pointer moves away from the button, reset the scale to normal
-				rulesButton.on("pointerout", () => {
-					rulesButton.setScale(1);
-				});
-
+				this.resize();
 				EventBus.emit("current-scene-ready", this);
 			},
 		});
+	}
+
+	resize() {
+		resize_constants(this);
+		this.titleText.setPosition(CENTER_WIDTH, 3 * DOZEN_HEIGHT);
+		this.introText.setPosition(CENTER_WIDTH, 8 * DOZEN_HEIGHT);
+		this.creditText.setPosition(CENTER_WIDTH, 11 * DOZEN_HEIGHT);
+		this.startButton.setPosition(CENTER_WIDTH, 5 * DOZEN_HEIGHT);
+		this.settingsButton.setPosition(10.5 * DOZEN_WIDTH, 1.5 * DOZEN_HEIGHT);
+		this.rulesButton.setPosition(10.5 * DOZEN_WIDTH, 9.5 * DOZEN_HEIGHT);
+		paddingTexts(
+			4 * UNIT_HEIGHT,
+			2 * UNIT_HEIGHT,
+			this.titleText,
+			this.introText,
+			this.creditText,
+			this.startButton,
+			this.settingsButton,
+			this.rulesButton
+		);
+		fontsizeTexts(2 * DOZEN_HEIGHT, this.titleText);
+		fontsizeTexts(2.5 * UNIT_WIDTH, this.creditText);
+		fontsizeTexts(6 * UNIT_HEIGHT, this.introText, this.startButton, this.settingsButton, this.rulesButton);
+		this.titleText.setStroke(START_TEXT_TWO, 2 * UNIT_HEIGHT);
+		this.introText.setWordWrapWidth(6 * DOZEN_WIDTH);
+		this.creditText.setFixedSize(WINDOW_WIDTH, 0);
 	}
 }


### PR DESCRIPTION
1. The scene and all of its components (text image etc) automatically resize when the window dimension changes.
2. The game accommodates width-to-height ratios from 16:10 to 21:9. Anything wider/narrower cuts off the extra width/height.  (the point is to fill up the entire screen when set to full screen on most devices).
3. Game Objects that were created but not assigned to a variable are now done so. A reference to the Game Object was necessary to resize it hence the change.
4. pieces-taken.js saw a major restructuring due to juggling a thousand different Game Objects being a pain. Now all the scores and images and texts are sorted into pretty dictionaries and the code is much more succinct.
5. The settings overlay was omitted due to it being grossly incomplete.
6. chessboard.test.js was adjusted to accommodate the invocation of new Game Object functions. No specific testing is added for the pull request since the only new thing is resizing which is purely visual and cannot be meaningfully tested via code.
7. Since the resizing functions already takes care of the Game Object position, size, font size, stroke thickness, padding etc those details were trimmed in the non-resizing portion of the code.
8. Miscellaneous code cleanups, for example excising the now unused logo.png star.png etc.