### PR TITLE
Fixed game over scene not ending game music

### DIFF
--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -153,4 +153,12 @@ export class Game extends Scene {
 		paddingTexts(4 * UNIT_HEIGHT, 2 * UNIT_HEIGHT, this.endButton, this.settingsButton, this.rulesButton);
 		this.chessTiles.resize();
 	}
+
+	// Function to stop the background music
+	stopMusic() {
+		if (this.gameMusicPlaying) {
+			this.gameMusic.stop();
+			this.gameMusicPlaying = false;
+		}
+	}
 }

--- a/src/game/scenes/GameOver.js
+++ b/src/game/scenes/GameOver.js
@@ -49,6 +49,14 @@ export class GameOver extends Scene {
 	}
 
 	create() {
+		// Access the Game scene
+		const gameScene = this.scene.get("MainGame");
+
+		// Call the stopMusic method of the Game scene
+		if (gameScene) {
+			gameScene.stopMusic();
+		}
+
 		// Play music
 		this.endMusic = this.sound.add("endMusic", {loop: false, volume: 0.5});
 		this.endMusicPlaying = false;


### PR DESCRIPTION
This is a small PR fixing the fact that the game music did not end when the game ended naturally (via checkmate)

There is now a function in the game scene that ends the game music, and this function is called in the game over scene. 