### PR TITLE
Fix for Dev Mode Toggle Button Functionality

### DIFF
--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -24,7 +24,7 @@ import {CHECKMATE, STALEMATE} from "./global-stats";
 import {setGlobalStatus, incrementGlobalMoves, incrementGlobalPieces, incrementGlobalWaves} from "./global-stats";
 import {resetGlobalStatus, resetGlobalMoves, resetGlobalPieces, resetGlobalWaves} from "./global-stats";
 
-import {dev_alignment, dev_rank, dev_bamzap, dev_stopOn, dev_deadAI} from "./dev-buttons";
+import {dev_alignment, dev_rank, dev_bamzap, dev_stopOn, dev_deadAI, DevButtons} from "./dev-buttons";
 import {BAM, ZAP} from "./dev-buttons";
 
 import {fontsizeTexts} from "./constants";
@@ -148,6 +148,7 @@ export class ChessTiles {
 
 		this.pieceCoordinates = new PieceCoordinates();
 		this.boardState = new BoardState(this.scene, this.pieceCoordinates);
+		this.devButtons = new DevButtons(this.scene, this);
 		this.piecesTaken = new PiecesTaken(this.scene);
 	}
 
@@ -178,6 +179,7 @@ export class ChessTiles {
 				this.chessTiles[i][j].setSize(TILE_SIZE, TILE_SIZE);
 			}
 		this.boardState.resize();
+		this.devButtons.resize();
 		this.piecesTaken.resize();
 	}
 

--- a/src/game-objects/constants.js
+++ b/src/game-objects/constants.js
@@ -204,3 +204,9 @@ export {EN_PASSANT_TOKEN};
 
 export {PAWN_VALUE, KNIGHT_VALUE, BISHOP_VALUE, ROOK_VALUE, QUEEN_VALUE, KING_VALUE};
 export {CAPTURE_WEIGHT, LOSS_WEIGHT, THREATEN_WEIGHT};
+
+let devButtons = null;
+export function setDevButtonsInitializedStatus(arg) {
+	devButtons = arg;
+}
+export {devButtons};

--- a/src/game-objects/dev-buttons.js
+++ b/src/game-objects/dev-buttons.js
@@ -5,6 +5,9 @@ import {CREAMHEX, ONYXHEX} from "./constants";
 import {configureButtons, paddingTexts, fontsizeTexts} from "./constants";
 import {LEFT_X_CENTER, LEFT_UNIT} from "./constants";
 
+import {setDevButtonsInitializedStatus} from "./constants";
+import {devButtons} from "./constants";
+
 const alignments = [PLAYER, COMPUTER];
 const alignment_names = ["white", "black"];
 const ranks = [PAWN, ROOK, KNIGHT, BISHOP, QUEEN, KING];
@@ -41,7 +44,13 @@ function toggleDev() {
 		prev_stopOn = dev_stopOn;
 		prev_deadAI = dev_deadAI;
 		dev_bamzap = dev_stopOn = dev_deadAI = false;
+	} else {
+		dev_bamzap = prev_bamzap;
+		dev_stopOn = prev_stopOn;
+		dev_deadAI = prev_deadAI;
 	}
+
+	if (devButtons) for (let button of devButtons.getNondevButtons()) button.visible = !button.visible;
 
 	return DEV_MODE;
 }
@@ -77,6 +86,8 @@ export class DevButtons {
 	constructor(scene, chessTiles) {
 		this.#scene = scene;
 		this.#chessTiles = chessTiles;
+
+		setDevButtonsInitializedStatus(this);
 
 		this.#devButton = this.#scene.add.text(0, 0, "", {
 			fill: CREAMHEX,

--- a/src/game-objects/test/chessboard.test.js
+++ b/src/game-objects/test/chessboard.test.js
@@ -564,7 +564,6 @@ describe("", () => {
 	});
 
 	test("Resize", () => {
-		// resize2 is commented out due to github exclusive npm run test error (runs fine on local)
 		window.innerWidth = 42 ** 42;
 		window.innerHeight = 42;
 		resize_constants();
@@ -576,16 +575,16 @@ describe("", () => {
 
 		const resize = jest.spyOn(tiles, "resize");
 		const resize1 = jest.spyOn(tiles.boardState, "resize");
-		// const resize2 = jest.spyOn(tiles.devButtons, "resize");
+		const resize2 = jest.spyOn(tiles.devButtons, "resize");
 		const resize3 = jest.spyOn(tiles.piecesTaken, "resize");
 		expect(resize).not.toHaveBeenCalled();
 		expect(resize1).not.toHaveBeenCalled();
-		// expect(resize2).not.toHaveBeenCalled();
+		expect(resize2).not.toHaveBeenCalled();
 		expect(resize3).not.toHaveBeenCalled();
 		for (let i = 0; i < 7; i++) tiles.resize();
 		expect(resize).toHaveBeenCalledTimes(7);
 		expect(resize1).toHaveBeenCalledTimes(7);
-		// expect(resize2).toHaveBeenCalledTimes(7);
+		expect(resize2).toHaveBeenCalledTimes(7);
 		expect(resize3).toHaveBeenCalledTimes(7);
 	});
 });

--- a/src/game/scenes/Settings.js
+++ b/src/game/scenes/Settings.js
@@ -1,7 +1,6 @@
 import Phaser from "phaser";
 import {COLOR_THEMES} from "../../game-objects/constants.js";
-import {toggleDev, DevButtons, DEV_MODE} from "../../game-objects/dev-buttons.js";
-import {ChessTiles} from "../../game-objects/chess-tiles";
+import {toggleDev, DEV_MODE} from "../../game-objects/dev-buttons.js";
 
 export class Settings extends Phaser.Scene {
 	constructor() {
@@ -64,20 +63,8 @@ export class Settings extends Phaser.Scene {
 			.setInteractive()
 			.on("pointerdown", () => {
 				console.log("Dev button clicked");
-				if (toggleDev()) {
-					// DEV_MODE is on: Create and show DevButtons
-					this.devButtons = new DevButtons(this.scene.get("MainGame"), ChessTiles);
-					this.devButtons.resize();
-					this.devButton.setText("Dev Mode: " + (DEV_MODE ? "ON" : "OFF"));
-				} else {
-					if (this.devButtons) {
-						// Hide the dev buttons by making them invisible
-						this.devButtons.getNondevButtons().forEach((button) => {
-							button.visible = false;
-						});
-					}
-					this.devButton.setText("Dev Mode: " + (DEV_MODE ? "ON" : "OFF"));
-				}
+				toggleDev();
+				this.devButton.setText("Dev Mode: " + (DEV_MODE ? "ON" : "OFF"));
 			});
 
 		// Close Button (Same Style as "Close Rules")


### PR DESCRIPTION
1. The dev mode toggle button now placed in Settings Scene now works as intended.
2. Specifically, possession of variable reference to DevButtons objects is returned to ChessTiles and removed from the Settings Scene. In addition, when DevButtons is first initialized the reference to it is added to constants.js.
3. How it works is when the dev mode toggle buttons is clicked, toggleDev() method is called.
4. If DevButtons is initialized (which can be verified via checking if aforementioned constant is null or not) then the button visibility is toggled, if not then not. DEV_MODE = !DEV_MODE regardless.
5. When DevButtons is first initialized if DEV_MODE = true then the dev buttons are set to visible and vice versa.