### PR TITLE
fix error when spawning pawns at 2nd final row

### DIFF
--- a/src/game-objects/board-state.js
+++ b/src/game-objects/board-state.js
@@ -263,7 +263,12 @@ export class BoardState {
 		// 2 tiles with first move
 		if (!this.isOccupied(col, j)) {
 			j += alignment == PLAYER ? -1 : 1;
-			if (!this.getMoveCounter(col, row) && !this.isOccupied(col, j) && this.kingSaved([col, row], [col, j], alignment))
+			if (
+				this.isValid(col, j) &&
+				!this.getMoveCounter(col, row) &&
+				!this.isOccupied(col, j) &&
+				this.kingSaved([col, row], [col, j], alignment)
+			)
 				moves.push({xy: [col, j], isEnemy: false});
 		}
 


### PR DESCRIPTION
Super quick fix for the "error when clicking on a pawn spawned on the 7th row due to the game recognizing that it never moved and trying to scout the space 2 tiles ahead".