### PR TITLE
Riana - Added functionality for muting the music

### DIFF
--- a/src/game-objects/global-stats.js
+++ b/src/game-objects/global-stats.js
@@ -2,10 +2,35 @@ let globalStatus = null;
 let globalMoves = 0;
 let globalPieces = 0;
 let globalWaves = 0;
+let globalMuteSound = false;
 
 const CHECKMATE = "Checkmate!";
 const STALEMATE = "Stalemate!";
 
+export function toggleGlobalMute(scene) {
+	globalMuteSound = !globalMuteSound;
+
+	// manage scene sounds
+	const gameScene = scene.scene.get("MainGame");
+	const startScene = scene.scene.get("Game");
+	const gameoverScene = scene.scene.get("GameOver");
+
+	// Start music
+	if (globalMuteSound == false) {
+		if (scene.scene.isVisible("Game")) {
+			startScene.startMusic();
+		} else if (scene.scene.isVisible("MainGame")) {
+			gameScene.startMusic();
+		} else if (scene.scene.isVisible("GameOver")) {
+			gameoverScene.startMusic();
+		}
+	} else {
+		// Stop music for current scene
+		if (startScene) startScene.stopMusic();
+		if (gameScene) gameScene.stopMusic();
+		if (gameoverScene) gameoverScene.stopMusic();
+	}
+}
 export function setGlobalStatus(status) {
 	globalStatus = status;
 }
@@ -31,5 +56,5 @@ export function resetGlobalWaves() {
 	globalWaves = 0;
 }
 
-export {globalStatus, globalMoves, globalPieces, globalWaves};
+export {globalStatus, globalMoves, globalPieces, globalWaves, globalMuteSound};
 export {CHECKMATE, STALEMATE};

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -10,6 +10,7 @@ import {RIGHT_X_CENTER} from "../../game-objects/constants";
 import {DOZEN_HEIGHT, UNIT_HEIGHT} from "../../game-objects/constants";
 import {configureButtons, paddingTexts, fontsizeTexts} from "../../game-objects/constants";
 import {getPieceStyle} from "./PieceStyle";
+import {globalMuteSound} from "../../game-objects/global-stats";
 
 import {
 	PAWN,
@@ -59,15 +60,11 @@ export class Game extends Scene {
 	}
 
 	create() {
-		// Play music
-		this.gameMusic = this.sound.add("gameMusic", {loop: false, volume: 1});
+		// Setup music
+		this.gameMusic = this.sound.add("gameMusic", {loop: false, volume: 0.5});
 		this.gameMusicPlaying = false;
 
-		// Play the music
-		this.gameMusic.play();
-		if (this.gameMusic.isPlaying) {
-			this.gameMusicPlaying = true;
-		}
+		this.startMusic();
 
 		// Manually loop specific part of the song
 		const loopStartTime = 44; // in seconds
@@ -113,8 +110,7 @@ export class Game extends Scene {
 				import("./GameOver") //
 					.then((module) => {
 						// Stop background music
-						this.gameMusic.stop();
-						this.gameMusicPlaying = false;
+						this.stopMusic();
 
 						// Only add the scene if it's not already registered
 						if (!this.scene.get("GameOver")) {
@@ -184,6 +180,16 @@ export class Game extends Scene {
 		if (this.gameMusicPlaying) {
 			this.gameMusic.stop();
 			this.gameMusicPlaying = false;
+		}
+	}
+
+	startMusic() {
+		// Play the music (if not muted)
+		if (globalMuteSound == false) {
+			this.gameMusic.play();
+			if (this.gameMusic.isPlaying) {
+				this.gameMusicPlaying = true;
+			}
 		}
 	}
 }

--- a/src/game/scenes/GameOver.js
+++ b/src/game/scenes/GameOver.js
@@ -1,6 +1,6 @@
 import {Scene} from "phaser";
 import {EventBus} from "../EventBus";
-import {globalMoves, globalPieces, globalWaves} from "../../game-objects/global-stats";
+import {globalMoves, globalPieces, globalWaves, globalMuteSound} from "../../game-objects/global-stats";
 
 import {paddingTexts, fontsizeTexts} from "../../game-objects/constants";
 import {
@@ -63,17 +63,11 @@ export class GameOver extends Scene {
 			gameScene.stopMusic();
 		}
 
-		// Play music
+		// Register music
 		this.endMusic = this.sound.add("endMusic", {loop: false, volume: 0.5});
 		this.endMusicPlaying = false;
 
-		// Music
-		this.endMusic = this.sound.add("endMusic", {loop: false, volume: 0.5});
-		// Try to play music without user click
-		this.endMusic.play();
-		if (this.endMusic.isPlaying) {
-			this.endMusicPlaying = true;
-		}
+		this.startMusic();
 
 		// put GAMEOVER over game screen
 		this.scene.moveAbove("MainGame", "GameOver");
@@ -134,8 +128,7 @@ export class GameOver extends Scene {
 		this.menuButton = this.createButton(0, 0, "Main Menu", () => {
 			console.log("Returning to main menu...");
 			// Stop background music
-			this.endMusic.stop();
-			this.endMusicPlaying = false;
+			this.stopMusic();
 			this.scene.stop("GameOver");
 			this.scene.stop("MainGame");
 			this.scene.start("Game");
@@ -143,9 +136,7 @@ export class GameOver extends Scene {
 
 		this.restartButton = this.createButton(0, 0, "Restart Game", () => {
 			console.log("Restarting game...");
-			// Stop background music
-			this.endMusic.stop();
-			this.endMusicPlaying = false;
+			this.stopMusic();
 			this.scene.stop("GameOver");
 			this.scene.stop("MainGame"); // Reset game state
 			this.scene.start("MainGame");
@@ -165,6 +156,20 @@ export class GameOver extends Scene {
 		this.resize();
 
 		EventBus.emit("current-scene-ready", this);
+	}
+
+	startMusic() {
+		// Try to play music without user click (if not muted)
+		if (globalMuteSound == false) this.endMusic.play();
+		if (this.endMusic.isPlaying) {
+			this.endMusicPlaying = true;
+		}
+	}
+
+	stopMusic() {
+		// Stop background music
+		this.endMusic.stop();
+		this.endMusicPlaying = false;
 	}
 
 	createStatText(x, y, label, value) {

--- a/src/game/scenes/Settings.js
+++ b/src/game/scenes/Settings.js
@@ -3,6 +3,7 @@ import {COLOR_THEMES} from "../../game-objects/constants.js";
 import {EventBus} from "../EventBus";
 import {setPieceStyle} from "./PieceStyle";
 import {toggleDev, DEV_MODE} from "../../game-objects/dev-buttons.js";
+import {globalMuteSound, toggleGlobalMute} from "../../game-objects/global-stats.js";
 
 export class Settings extends Phaser.Scene {
 	constructor() {
@@ -128,6 +129,20 @@ export class Settings extends Phaser.Scene {
 			.on("pointerdown", () => {
 				toggleDev();
 				this.devButton.setText("Dev Mode: " + (DEV_MODE ? "ON" : "OFF"));
+			});
+
+		// Music Toggle Button
+		this.muteButton = this.add
+			.text(400, yOffset, globalMuteSound ? "Unmute Music" : "Mute Music", {
+				fontSize: "18px",
+				fill: "#f28d3e",
+				backgroundColor: "#333",
+				padding: {x: 10, y: 5},
+			})
+			.setInteractive()
+			.on("pointerdown", () => {
+				toggleGlobalMute(this);
+				this.muteButton.setText(globalMuteSound ? "Unmute Music" : "Mute Music");
 			});
 
 		// Close Button (Same Style as "Close Rules")

--- a/src/game/scenes/Start.js
+++ b/src/game/scenes/Start.js
@@ -1,5 +1,6 @@
 import {Scene} from "phaser";
 import {EventBus} from "../EventBus";
+import {globalMuteSound} from "../../game-objects/global-stats";
 
 import {configureButtons, paddingTexts, fontsizeTexts} from "../../game-objects/constants";
 import {resize_constants} from "../../game-objects/constants";
@@ -31,18 +32,12 @@ export class Start extends Scene {
 			active: () => {
 				this.fontLoaded = true;
 
-				// === Play Music ===
+				// Register music
 				this.backgroundMusic = this.sound.add("backgroundMusic", {loop: true, volume: 0.5});
-				if (!this.backgroundMusic.isPlaying) {
-					this.backgroundMusic.play();
-					this.backgroundMusicPlaying = true;
-				}
+				this.startMusic();
 
 				this.input.on("pointerdown", () => {
-					if (!this.backgroundMusic.isPlaying) {
-						this.backgroundMusic.play();
-						this.backgroundMusicPlaying = true;
-					}
+					this.startMusic();
 				});
 
 				// === Color Themes ===
@@ -115,8 +110,7 @@ export class Start extends Scene {
 				});
 				this.startButton.setInteractive().on("pointerdown", () => {
 					import("./Game").then((module) => {
-						this.backgroundMusic.stop();
-						this.backgroundMusicPlaying = false;
+						this.stopMusic();
 						if (!this.scene.get("MainGame")) {
 							this.scene.add("MainGame", module.Game);
 						}
@@ -174,8 +168,7 @@ export class Start extends Scene {
 				// === Handle Theme Change ===
 				EventBus.on("PaletteChanged", () => {
 					if (this.backgroundMusic && this.backgroundMusic.isPlaying) {
-						this.backgroundMusic.stop();
-						this.backgroundMusicPlaying = false;
+						this.stopMusic();
 					}
 					if (this.scene.isVisible("Game")) {
 						this.scene.restart();
@@ -183,6 +176,18 @@ export class Start extends Scene {
 				});
 			},
 		});
+	}
+
+	startMusic() {
+		if (!this.backgroundMusic.isPlaying && globalMuteSound == false) {
+			this.backgroundMusic.play();
+			this.backgroundMusicPlaying = true;
+		}
+	}
+
+	stopMusic() {
+		this.backgroundMusic.stop();
+		this.backgroundMusicPlaying = false;
 	}
 
 	resize() {


### PR DESCRIPTION
As we discussed, a way to mute the music would be beneficial. I added a button to the setting scene that allows for the music to be muted. 

Start.js, Game.js, GameOver.js
- I made functions for starting and stoping the music 

Settings.js
- New button that toggles the mute of music

global-stats.js
- Keeps track of a new global variable, if music is muted or not
- New function for toggling music. If music should be off, it will stop all music. If music should be on, it will play music for the current scene