### PR TITLE
Riana - Added rectangle to cover buttons

### DIFF
--- a/src/game/scenes/GameOver.js
+++ b/src/game/scenes/GameOver.js
@@ -50,6 +50,12 @@ export class GameOver extends Scene {
 			light: {text: 0x3b3b3b, background: 0xffffff},
 		}[selectedPalette];
 
+		const backgroundColor = {
+			default: {background: 0x3b3b3b},
+			dark: {background: 0x222222},
+			light: {background: 0xffffff},
+		}[selectedPalette];
+
 		// Access the Game scene
 		const gameScene = this.scene.get("MainGame");
 		this.buttonTextColor = themeColors.text;
@@ -73,6 +79,8 @@ export class GameOver extends Scene {
 		this.scene.moveAbove("MainGame", "GameOver");
 		// Creates an invisible background that also blocks input on the scene underneath
 		this.bg = this.add.rectangle(1, 1, 1, 1, GAMEOVER_BACKGROUND_COLOR, 0);
+		// Creates a rectangle that covers the buttons on the game scene
+		this.buttonCover = this.add.rectangle(1, 1, 1, 1, backgroundColor.background, 1.0);
 
 		// Creates a visual background that also blocks input on the scene underneath
 		this.square = this.add.rectangle(
@@ -251,6 +259,8 @@ export class GameOver extends Scene {
 	resize() {
 		this.bg.setPosition(CENTER_WIDTH, CENTER_HEIGHT);
 		this.bg.setSize(WINDOW_WIDTH, WINDOW_HEIGHT);
+		this.buttonCover.setPosition(10 * DOZEN_WIDTH, 10 * DOZEN_HEIGHT);
+		this.buttonCover.setSize(10 * DOZEN_HEIGHT, 6 * DOZEN_HEIGHT);
 		this.square.setPosition(CENTER_WIDTH, CENTER_HEIGHT);
 		this.square.setSize(10 * DOZEN_HEIGHT, 10 * DOZEN_HEIGHT);
 		this.titleText.setPosition(CENTER_WIDTH, 2 * DOZEN_HEIGHT);


### PR DESCRIPTION
I got feedback that when in the game over scene, the buttons on the game scene look clickable when they are not. I added a rectangle that covers these buttons. 

GameOver.js
- Added a color switcher to make the rectangle in the current background color
- Added a rectangle that covers the buttons in said color
- Added resize code for said rectangle