### PR TITLE
fixed promotion issue

### DIFF
--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -680,8 +680,10 @@ export class ChessTiles {
 	}
 
 	setPromotion(rank, alignment) {
-		this.boardState.destroyPiece(this.promotionCol, this.promotionRow); // might need update with capture
-		this.boardState.addPiece(this.promotionCol, this.promotionRow, rank, alignment);
+		if (this.boardState.getRank(this.promotionCol, this.promotionRow) == rank) {
+			this.boardState.destroyPiece(this.promotionCol, this.promotionRow); // might need update with capture
+			this.boardState.addPiece(this.promotionCol, this.promotionRow, rank, alignment);
+		}
 	}
 
 	makeComputerMove() {

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -680,7 +680,7 @@ export class ChessTiles {
 	}
 
 	setPromotion(rank, alignment) {
-		if (this.boardState.getRank(this.promotionCol, this.promotionRow) == rank) {
+		if (this.boardState.getAlignment(this.promotionCol, this.promotionRow) == alignment) {
 			this.boardState.destroyPiece(this.promotionCol, this.promotionRow); // might need update with capture
 			this.boardState.addPiece(this.promotionCol, this.promotionRow, rank, alignment);
 		}


### PR DESCRIPTION
fixed issue where if AI took piece before player chose promotion player piece would end up taking computer's piece. 

SetPromotion now checks if the piece is of the player's alignment before replacing it. Will see capturedPieces as capturing a pawn, but that's kinda minor imo