### PR TITLE
Riana - Change rectangle cover to destroy buttons

### DIFF
--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -437,13 +437,18 @@ export class ChessTiles {
 		if (this.boardState.isCheckmated(this.currentPlayer)) status = CHECKMATE;
 		if (this.boardState.isStalemated(this.currentPlayer)) status = STALEMATE;
 		setGlobalStatus(status);
-		if (status)
+		if (status) {
+			const gameScene = this.scene.scene.get("MainGame");
+			if (gameScene) {
+				gameScene.destroyButtons();
+			}
 			import("../game/scenes/GameOver").then((module) => {
 				// Only add the scene if it's not already registered
 				if (!this.scene.scene.get("GameOver")) this.scene.scene.add("GameOver", module.GameOver);
 				// Start the GameOver scene
 				this.scene.scene.launch("GameOver");
 			});
+		}
 	}
 
 	// ================================================================

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -112,6 +112,11 @@ export class Game extends Scene {
 						// Stop background music
 						this.stopMusic();
 
+						// Make buttons invisible
+						this.rulesButton.destroy();
+						this.settingsButton.destroy();
+						this.endButton.destroy();
+
 						// Only add the scene if it's not already registered
 						if (!this.scene.get("GameOver")) {
 							this.scene.add("GameOver", module.GameOver); // Add the MainGame scene dynamically

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -112,10 +112,7 @@ export class Game extends Scene {
 						// Stop background music
 						this.stopMusic();
 
-						// Make buttons invisible
-						this.rulesButton.destroy();
-						this.settingsButton.destroy();
-						this.endButton.destroy();
+						this.destroyButtons();
 
 						// Only add the scene if it's not already registered
 						if (!this.scene.get("GameOver")) {
@@ -196,5 +193,12 @@ export class Game extends Scene {
 				this.gameMusicPlaying = true;
 			}
 		}
+	}
+
+	destroyButtons() {
+		// Make buttons invisible
+		this.rulesButton.destroy();
+		this.settingsButton.destroy();
+		this.endButton.destroy();
 	}
 }

--- a/src/game/scenes/GameOver.js
+++ b/src/game/scenes/GameOver.js
@@ -50,12 +50,6 @@ export class GameOver extends Scene {
 			light: {text: 0x3b3b3b, background: 0xffffff},
 		}[selectedPalette];
 
-		const backgroundColor = {
-			default: {background: 0x3b3b3b},
-			dark: {background: 0x222222},
-			light: {background: 0xffffff},
-		}[selectedPalette];
-
 		// Access the Game scene
 		const gameScene = this.scene.get("MainGame");
 		this.buttonTextColor = themeColors.text;
@@ -79,8 +73,6 @@ export class GameOver extends Scene {
 		this.scene.moveAbove("MainGame", "GameOver");
 		// Creates an invisible background that also blocks input on the scene underneath
 		this.bg = this.add.rectangle(1, 1, 1, 1, GAMEOVER_BACKGROUND_COLOR, 0);
-		// Creates a rectangle that covers the buttons on the game scene
-		this.buttonCover = this.add.rectangle(1, 1, 1, 1, backgroundColor.background, 1.0);
 
 		// Creates a visual background that also blocks input on the scene underneath
 		this.square = this.add.rectangle(
@@ -259,8 +251,6 @@ export class GameOver extends Scene {
 	resize() {
 		this.bg.setPosition(CENTER_WIDTH, CENTER_HEIGHT);
 		this.bg.setSize(WINDOW_WIDTH, WINDOW_HEIGHT);
-		this.buttonCover.setPosition(10 * DOZEN_WIDTH, 10 * DOZEN_HEIGHT);
-		this.buttonCover.setSize(10 * DOZEN_HEIGHT, 6 * DOZEN_HEIGHT);
 		this.square.setPosition(CENTER_WIDTH, CENTER_HEIGHT);
 		this.square.setSize(10 * DOZEN_HEIGHT, 10 * DOZEN_HEIGHT);
 		this.titleText.setPosition(CENTER_WIDTH, 2 * DOZEN_HEIGHT);


### PR DESCRIPTION
I have removed the rectangle cover of the buttons on the game over scene. Instead I made a function in Game.js that destroys the buttons when the game is over

Game.js
- new function to destroy buttons
- function is called on click for end game button

GameOver.js
- remove rectangle code

chess-tiles.js
- call destroy buttons on game end