### PR TITLE
Riana - Player piece moves before computer

### DIFF
--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -420,7 +420,6 @@ export class ChessTiles {
 							if (!--this.turnsUntilNextWave) this.spawnNextWave();
 						}, 300);
 					}
-					if (!--this.turnsUntilNextWave) this.spawnNextWave();
 				} else {
 					// No moves means we clear all pieces and instantly start the next wave
 					this.boardState.zapPieces(COMPUTER);

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -414,7 +414,11 @@ export class ChessTiles {
 				if (computerHasValidMove) {
 					this.currentPlayer = COMPUTER;
 					if (!dev_deadAI) {
-						this.makeComputerMove(); // do the computer move
+						// Delay computer move slightly
+						setTimeout(() => {
+							this.makeComputerMove();
+							if (!--this.turnsUntilNextWave) this.spawnNextWave();
+						}, 300);
 					}
 					if (!--this.turnsUntilNextWave) this.spawnNextWave();
 				} else {
@@ -689,18 +693,15 @@ export class ChessTiles {
 
 	makeComputerMove() {
 		EventBus.once("ComputerMove", async (detail) => {
-			// Set a timeout to create a delay (allows for animation of white piece to finish)
-			setTimeout(async () => {
-				console.log("move: " + detail[0] + " to " + detail[1], detail[2]);
-				if (this.boardState.isOccupied(detail[1][0], detail[1][1])) {
-					this.capturePiece(this.boardState.getRank(detail[1][0], detail[1][1]), PLAYER);
-					this.boardState.destroyPiece(detail[1][0], detail[1][1]);
-				}
-				this.boardState.movePiece(detail[0], detail[1]); // make the move given
-				this.checkPromotion(detail[1]);
-				// this.currentPlayer = PLAYER;
-				this.toggleTurn();
-			}, 300); // 300 milliseconds delay
+			console.log("move: " + detail[0] + " to " + detail[1], detail[2]);
+			if (this.boardState.isOccupied(detail[1][0], detail[1][1])) {
+				this.capturePiece(this.boardState.getRank(detail[1][0], detail[1][1]), PLAYER);
+				this.boardState.destroyPiece(detail[1][0], detail[1][1]);
+			}
+			this.boardState.movePiece(detail[0], detail[1]); // make the move given
+			this.checkPromotion(detail[1]);
+			// this.currentPlayer = PLAYER;
+			this.toggleTurn();
 		});
 		this.futureMoves = new ChessGameState(this.boardState.cloneBoardState());
 		this.futureMoves.getBestMove();

--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -417,9 +417,9 @@ export class ChessTiles {
 						// Delay computer move slightly
 						setTimeout(() => {
 							this.makeComputerMove();
-							if (!--this.turnsUntilNextWave) this.spawnNextWave();
 						}, 300);
 					}
+					if (!--this.turnsUntilNextWave) this.spawnNextWave();
 				} else {
 					// No moves means we clear all pieces and instantly start the next wave
 					this.boardState.zapPieces(COMPUTER);


### PR DESCRIPTION
I found a solution to our problem where the white piece would not move until the black piece was ready to, and they would move simultaneously. 

chess-tiles.js
- I added a delay to the this.makeComputerMove() call
- I removed delay from makeComputerMove() method

Now, white piece moves right when the user clicks and then when ready black piece moves