### PR TITLE
Fix game not resizing when gameover due to destroy

### DIFF
--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -154,11 +154,13 @@ export class Game extends Scene {
 	}
 
 	resize() {
-		this.settingsButton.setPosition(RIGHT_X_CENTER, 9 * DOZEN_HEIGHT);
-		this.rulesButton.setPosition(RIGHT_X_CENTER, 10 * DOZEN_HEIGHT);
-		this.endButton.setPosition(RIGHT_X_CENTER, 11 * DOZEN_HEIGHT);
-		fontsizeTexts(6 * UNIT_HEIGHT, this.endButton, this.settingsButton, this.rulesButton);
-		paddingTexts(4 * UNIT_HEIGHT, 2 * UNIT_HEIGHT, this.endButton, this.settingsButton, this.rulesButton);
+		if (this.settingsButton.active && this.rulesButton.active && this.endButton.active) {
+			this.settingsButton.setPosition(RIGHT_X_CENTER, 9 * DOZEN_HEIGHT);
+			this.rulesButton.setPosition(RIGHT_X_CENTER, 10 * DOZEN_HEIGHT);
+			this.endButton.setPosition(RIGHT_X_CENTER, 11 * DOZEN_HEIGHT);
+			fontsizeTexts(6 * UNIT_HEIGHT, this.endButton, this.settingsButton, this.rulesButton);
+			paddingTexts(4 * UNIT_HEIGHT, 2 * UNIT_HEIGHT, this.endButton, this.settingsButton, this.rulesButton);
+		}
 		this.chessTiles.resize();
 	}
 	changeBackground() {


### PR DESCRIPTION
When End game button is clicked the settings & rules & end game buttons are destroyed. When resizing is attempted the game tries to resize those buttons but they're destroyed so they can't be resized. So an error occurs and game scene is not resized. That bug is now fixed.