### PR TITLE
made waves spawn after computer moves

### DIFF
--- a/src/game-objects/chess-tiles.js
+++ b/src/game-objects/chess-tiles.js
@@ -417,9 +417,11 @@ export class ChessTiles {
 						// Delay computer move slightly
 						setTimeout(() => {
 							this.makeComputerMove();
+							if (!--this.turnsUntilNextWave) this.spawnNextWave();
 						}, 300);
+					} else {
+						if (!--this.turnsUntilNextWave) this.spawnNextWave();
 					}
-					if (!--this.turnsUntilNextWave) this.spawnNextWave();
 				} else {
 					// No moves means we clear all pieces and instantly start the next wave
 					this.boardState.zapPieces(COMPUTER);
@@ -440,7 +442,7 @@ export class ChessTiles {
 		if (this.boardState.isCheckmated(this.currentPlayer)) status = CHECKMATE;
 		if (this.boardState.isStalemated(this.currentPlayer)) status = STALEMATE;
 		setGlobalStatus(status);
-    console.log(status, this.currentPlayer);
+		// console.log(status, this.currentPlayer);
 		if (status) {
 			const gameScene = this.scene.scene.get("MainGame");
 			if (gameScene) {
@@ -697,7 +699,7 @@ export class ChessTiles {
 
 	makeComputerMove() {
 		EventBus.once("ComputerMove", async (detail) => {
-			console.log("move: " + detail[0] + " to " + detail[1], detail[2]);
+			// console.log("move: " + detail[0] + " to " + detail[1], detail[2]);
 			if (this.boardState.isOccupied(detail[1][0], detail[1][1])) {
 				this.capturePiece(this.boardState.getRank(detail[1][0], detail[1][1]), PLAYER);
 				this.boardState.destroyPiece(detail[1][0], detail[1][1]);

--- a/src/game-objects/computer-logic.js
+++ b/src/game-objects/computer-logic.js
@@ -57,6 +57,7 @@ export class ChessGameState {
 		// if there is a capture move, make it
 		if (bestMove) {
 			this.sendMove(bestMove[1], bestMove[2], bestMove[3]);
+			return; // break here
 		}
 
 		// otherwise examine all moves


### PR DESCRIPTION
Put this.spawnNextWave() call inside delay call which has makeComputerMove as makeComputerMove is asynchronous so sometimes the next wave would spawn before the computer makes its move. It then sometimes would try to capture the white king immediately and the move fails.

Also added return to ChessGameState's getBestMove() method if it finds an immediate capture instead of continuing to run after it already makes a move.

Lastly, re-removed some console.log statements.